### PR TITLE
Improve CQ2

### DIFF
--- a/MatrixIO.IO.Bmff/IO/Bmff/BaseMediaReader.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/BaseMediaReader.cs
@@ -15,7 +15,7 @@ namespace MatrixIO.IO.Bmff
 
         public BaseMediaReader(Stream stream, BaseMediaOptions options = BaseMediaOptions.None)
         {
-            if (stream.CanSeek && stream.Position!=0) stream.Seek(0, SeekOrigin.Begin);
+            if (stream.CanSeek && stream.Position != 0) stream.Seek(0, SeekOrigin.Begin);
             BaseStream = stream;
             Options = options;
         }
@@ -27,9 +27,13 @@ namespace MatrixIO.IO.Bmff
             get
             {
                 var path = new StringBuilder();
-                foreach(var box in _boxStack) 
+                foreach (var box in _boxStack)
                 {
-                    if(path.Length > 0) path.Append("|");
+                    if (path.Length > 0)
+                    {
+                        path.Append('|');
+                    }
+
                     path.Append(box.ToString());
                 }
                 return path.ToString();
@@ -42,7 +46,11 @@ namespace MatrixIO.IO.Bmff
         {
             get
             {
-                if(_boxStack.Count == 0) _boxStack.Push(Box.FromStream(BaseStream, BaseMediaOptions.None));
+                if (_boxStack.Count == 0)
+                {
+                    _boxStack.Push(Box.FromStream(BaseStream, BaseMediaOptions.None));
+                }
+
                 return _boxStack.Peek();
             }
         }
@@ -52,6 +60,7 @@ namespace MatrixIO.IO.Bmff
         public void NextSibling()
         {
             CurrentBox.Sync(BaseStream, false);
+
             if (Depth > 1)
             {
                 _boxStack.Pop();
@@ -67,7 +76,8 @@ namespace MatrixIO.IO.Bmff
                 //if (currentSuperBox.Children != null & currentSuperBox.Children.Count > 0) ;
                 throw new NotImplementedException();
             }
-            else NextSibling();
+            
+            NextSibling();
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/BmffReader.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/BmffReader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 
@@ -15,7 +16,7 @@ namespace MatrixIO.IO.Bmff
             get
             {
 #pragma warning disable 612,618
-                if (_rootBoxes == null) return _rootBoxes = new List<Box>(GetBoxes());
+                if (_rootBoxes is null) return _rootBoxes = new List<Box>(GetBoxes());
 #pragma warning restore 612,618
                 return _rootBoxes;
             }
@@ -24,25 +25,20 @@ namespace MatrixIO.IO.Bmff
         public bool RandomAccess => _baseStream.CanSeek;
 
         #region Navigation
+
         private readonly Stack<Box> _boxStack = new Stack<Box>();
 
         public int Depth => _boxStack.Count;
 
         public Box CurrentBox => _boxStack.Peek();
 
-        public bool HasChildren
-        {
-            get
-            {
-                if (CurrentBox is ISuperBox) return true;
-                else return false;
-            }
-        }
+        public bool HasChildren => CurrentBox is ISuperBox;
+
         #endregion
 
         public BmffReader(Stream stream)
         {
-            if (stream.CanSeek && stream.Position!=0) stream.Seek(0, SeekOrigin.Begin);
+            if (stream.CanSeek && stream.Position != 0) stream.Seek(0, SeekOrigin.Begin);
             _baseStream = stream;
         }
 
@@ -66,6 +62,7 @@ namespace MatrixIO.IO.Bmff
                 if (box != null) yield return box;
             } while (box != null);
         }
+
         /// <summary>
         /// Seeks to the beginning of the file and reads the "ftyp" Box.
         /// </summary>
@@ -73,7 +70,10 @@ namespace MatrixIO.IO.Bmff
         [Obsolete]
         public Boxes.FileTypeBox GetFileTypeBox()
         {
-            if (_baseStream.CanSeek && _baseStream.Position!=0) _baseStream.Seek(0, SeekOrigin.Begin);
+            if (_baseStream.CanSeek && _baseStream.Position != 0)
+            {
+                _baseStream.Seek(0, SeekOrigin.Begin);
+            }
 
             // TODO: Support files where "ftyp" is not the first FourCC like JPEG2000.
             return Box.FromStream<Boxes.FileTypeBox>(_baseStream);
@@ -97,7 +97,10 @@ namespace MatrixIO.IO.Bmff
             {
                 mfraOffset = BitConverter.ToUInt32(mfrobuf, 20).NetworkToHostOrder();
             }
-            else return null;
+            else
+            {
+                return null;
+            }
 
             _baseStream.Seek(-mfraOffset, SeekOrigin.End);
 
@@ -108,15 +111,9 @@ namespace MatrixIO.IO.Bmff
         IList<Box> ISuperBox.Children => RootBoxes;
 
         [Obsolete("Use the BaseMedia class instead.")]
-        IEnumerator<Box> IEnumerable<Box>.GetEnumerator()
-        {
-            return RootBoxes.GetEnumerator();
-        }
+        IEnumerator<Box> IEnumerable<Box>.GetEnumerator() => RootBoxes.GetEnumerator();
 
         [Obsolete("Use the BaseMedia class instead.")]
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return RootBoxes.GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => RootBoxes.GetEnumerator();
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Box.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Box.cs
@@ -3,15 +3,20 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Diagnostics;
+using System.Linq;
 
 namespace MatrixIO.IO.Bmff
 {
     public abstract class Box
     {
+        const int uuidType = 0x75756964; // 
+
         protected Stream _sourceStream;
+
         public Stream SourceStream => _sourceStream;
 
         public ulong? Offset { get; protected set; }
+
         public ulong? ContentOffset { get; protected set; }
 
         public ulong? ContentSize
@@ -26,24 +31,23 @@ namespace MatrixIO.IO.Bmff
             }
         }
 
-        public bool HasContent
-        {
-            get
-            {
-                if (ContentSize.HasValue && ContentSize > 0) return true;
-                else return false;
-            }
-        }
+        public bool HasContent => ContentSize.HasValue && ContentSize > 0;
 
         public uint Size { get; protected set; }
+
         public ulong? LargeSize { get; protected set; }
+
         public ulong EffectiveSize
         {
             get
             {
                 if (Size == 0)
                 {
-                    if (_sourceStream is null) return long.MaxValue;
+                    if (_sourceStream is null)
+                    {
+                        return long.MaxValue;
+                    }
+
                     try
                     {
                         return (ulong)_sourceStream.Length;
@@ -53,8 +57,14 @@ namespace MatrixIO.IO.Bmff
                         return long.MaxValue;
                     }
                 }
-                else if (Size != 1) return Size;
-                else return LargeSize.HasValue ? LargeSize.Value : 0;
+                else if (Size != 1)
+                {
+                    return Size;
+                }
+                else
+                {
+                    return LargeSize ?? 0;
+                }
             }
             protected set
             {
@@ -79,15 +89,31 @@ namespace MatrixIO.IO.Bmff
         {
             ulong calculatedSize = (ulong)(Size == 1 ? 16 : 8);
 
-            if (this is ISuperBox)
-                foreach (Box box in ((ISuperBox)this).Children) calculatedSize += box.CalculateSize();
+            if (this is ISuperBox superBox)
+            {
+                foreach (Box box in superBox.Children)
+                {
+                    calculatedSize += box.CalculateSize();
+                }
+            }
 
             // TODO: CalculateSize for IContentBox will have to change one the event model is done.
             if (this is IContentBox)
             {
-                if (ContentSize.HasValue) calculatedSize += ContentSize.Value;
-                else if (SourceStream != null && SourceStream.CanSeek) calculatedSize += ContentOffset.HasValue ? (ulong)SourceStream.Length - ContentOffset.Value : (ulong)SourceStream.Length;
-                else return 0;
+                if (ContentSize.HasValue)
+                {
+                    calculatedSize += ContentSize.Value;
+                }
+                else if (SourceStream != null && SourceStream.CanSeek)
+                {
+                    calculatedSize += ContentOffset.HasValue
+                        ? (ulong)SourceStream.Length - ContentOffset.Value
+                        : (ulong)SourceStream.Length;
+                }
+                else
+                {
+                    return 0;
+                }
             }
 
             return calculatedSize;
@@ -97,36 +123,56 @@ namespace MatrixIO.IO.Bmff
 
         protected Box()
         {
-            BoxAttribute[] boxAttributes = (BoxAttribute[])this.GetType().GetCustomAttributes(typeof(BoxAttribute), true);
-            if (boxAttributes != null && boxAttributes.Length != 0) Type = boxAttributes[0].Type;
+            var firstBoxAttribute = this.GetType().GetCustomAttributes<BoxAttribute>(true).FirstOrDefault();
+
+            if (firstBoxAttribute != null)
+            {
+                Type = firstBoxAttribute.Type;
+            }
             else if (!(this is Boxes.UnknownBox))
+            {
                 throw new Exception("BMFF Box derivative is not decorated with a BoxAttribute.");
+            }
         }
 
         /// <summary>
         /// Deserializes a specific box type from the stream. 
         /// </summary>
-        /// <exception cref="System.FormatException">Thrown when the next box in the stream is not the expected type.</exception>
+        /// <exception cref="FormatException">Thrown when the next box in the stream is not the expected type.</exception>
         /// <param name="stream">Stream containing the box to be deserialized at the current position.</param>
         protected Box(Stream stream)
         {
             Offset = (ulong)stream.Position;
 
             Size = stream.ReadBEUInt32();
-            uint type = stream.ReadBEUInt32();
-            if (Size == 1) LargeSize = stream.ReadBEUInt64();
 
-            if (type == 0x75756964) // 'uuid'
+            uint type = stream.ReadBEUInt32();
+
+            if (Size == 1)
             {
-                Type = new BoxType(new Guid(stream.ReadBytes(16)));
+                LargeSize = stream.ReadBEUInt64();
             }
-            else Type = new BoxType(type);
+         
+            Type = (type == uuidType)
+                ? new BoxType(new Guid(stream.ReadBytes(16)))
+                : new BoxType(type);
 
             bool foundMatchingAttribute = false;
-            object[] boxAttributes = this.GetType().GetCustomAttributes(typeof(BoxAttribute), true);
-            foreach (BoxAttribute boxAttribute in boxAttributes) if (boxAttribute.Type == Type) foundMatchingAttribute = true;
+
+            var boxAttributes = this.GetType().GetCustomAttributes<BoxAttribute>(inherit: true);
+
+            foreach (BoxAttribute boxAttribute in boxAttributes)
+            {
+                if (boxAttribute.Type == Type)
+                {
+                    foundMatchingAttribute = true;
+                }
+            }
+
             if (!foundMatchingAttribute)
+            {
                 throw new FormatException("Unexpected BMFF Box Type.");
+            }
 
             Initialize(stream);
         }
@@ -134,6 +180,7 @@ namespace MatrixIO.IO.Bmff
         internal void Initialize(Stream stream, BaseMediaOptions options = BaseMediaOptions.LoadChildren)
         {
             Trace.WriteLine(Type, "Loading");
+
             _sourceStream = stream;
 
             ConstrainedStream constrainedStream = ConstrainedStream.WrapStream(stream);
@@ -145,12 +192,15 @@ namespace MatrixIO.IO.Bmff
             ContentOffset = (ulong)stream.Position;
 
             if (((options & BaseMediaOptions.LoadChildren) == BaseMediaOptions.LoadChildren) && this is ISuperBox)
+            {
                 LoadChildrenFromStream(stream);
+            }
 
             Sync(stream, !(this is IContentBox));
 
             constrainedStream.PopConstraint();
         }
+
         /// <summary>
         /// Seek or read ahead to the beginning of the next Box.
         /// </summary>
@@ -159,21 +209,28 @@ namespace MatrixIO.IO.Bmff
         protected internal void Sync(Stream stream, bool warn = true)
         {
             ulong targetPosition = Offset.Value + EffectiveSize;
+
             if (stream.CanSeek)
             {
                 long position = stream.Position;
 
                 if (position < (long)targetPosition)
                 {
-                    if (warn) Trace.WriteLine("Failed to read all bytes in " + this + " box.  Seeking ahead.", "WARNING");
-                    stream.Seek((long)targetPosition, SeekOrigin.Begin);
+                    if (warn)
+                    {
+                        Trace.WriteLine("Failed to read all bytes in " + this + " box.  Seeking ahead.", "WARNING");
+                    }
 
+                    stream.Seek((long)targetPosition, SeekOrigin.Begin);
                 }
             }
             else
             {
                 // TODO: do this in blocks for performance reasons
-                while ((ulong)stream.Position < targetPosition) stream.ReadOneByte();
+                while ((ulong)stream.Position < targetPosition)
+                {
+                    stream.ReadOneByte();
+                }
             }
         }
 
@@ -183,12 +240,14 @@ namespace MatrixIO.IO.Bmff
         {
 
             Trace.Indent();
+
             while ((ulong)stream.Position < Offset + EffectiveSize)
             {
                 Box box = Box.FromStream(stream);
                 if (box != null) ((ISuperBox)this).Children.Add(box);
                 else break;
             }
+
             Trace.Unindent();
         }
 
@@ -197,10 +256,12 @@ namespace MatrixIO.IO.Bmff
         protected virtual void SaveChildrenToStream(Stream stream)
         {
             Trace.Indent();
+
             foreach (Box box in ((ISuperBox)this).Children)
             {
                 box.ToStream(stream);
             }
+
             Trace.Unindent();
         }
 
@@ -212,6 +273,7 @@ namespace MatrixIO.IO.Bmff
         public static Box FromStream(Stream stream, BaseMediaOptions options = BaseMediaOptions.LoadChildren)
         {
             Box box = null;
+
             try
             {
                 ulong offset = (ulong)stream.Position;
@@ -219,17 +281,17 @@ namespace MatrixIO.IO.Bmff
                 uint size = stream.ReadBEUInt32();
                 uint type = stream.ReadBEUInt32();
                 ulong? largeSize = null;
-                if (size == 1) largeSize = stream.ReadBEUInt64();
 
-                BoxType boxType;
-                if (type == 0x75756964) // 'uuid'
+                if (size == 1)
                 {
-                    boxType = new BoxType(new Guid(stream.ReadBytes(16)));
+                    largeSize = stream.ReadBEUInt64();
                 }
-                else boxType = new BoxType(type);
 
-                Type t = null;
-                AvailableBoxTypes.TryGetValue(boxType, out t);
+                BoxType boxType = (type == uuidType)
+                    ? new BoxType(new Guid(stream.ReadBytes(16)))
+                    : new BoxType(type);
+
+                AvailableBoxTypes.TryGetValue(boxType, out Type t);
 
                 box = t != null ? (Box)Activator.CreateInstance(t) : new Boxes.UnknownBox(boxType);
 
@@ -248,10 +310,12 @@ namespace MatrixIO.IO.Bmff
         static Box()
         {
             AvailableBoxTypes = new Dictionary<BoxType, Type>();
+
             foreach (var boxType in GetBoxTypes(Assembly.GetExecutingAssembly()))
             {
                 AvailableBoxTypes.Add(boxType);
             }
+
             Debug.WriteLine("Available Box Types: " + AvailableBoxTypes.Count);
         }
 
@@ -276,10 +340,15 @@ namespace MatrixIO.IO.Bmff
             foreach (KeyValuePair<BoxType, Type> typeMapping in GetBoxTypes(assembly))
             {
                 if (AvailableBoxTypes.ContainsKey(typeMapping.Key))
+                {
                     AvailableBoxTypes[typeMapping.Key] = typeMapping.Value;
+                }
                 else
+                {
                     AvailableBoxTypes.Add(typeMapping.Key, typeMapping.Value);
+                }
             }
+
             Debug.WriteLine("Available Box Types: " + AvailableBoxTypes.Count);
         }
 
@@ -291,20 +360,40 @@ namespace MatrixIO.IO.Bmff
             long offset = constrainedStream.Position;
 
             ulong calculatedLength = CalculateSize() + (ulong)(Size == 1 ? 0 : 8);
+
             uint size = 1;
             ulong largeSize = 0;
-            if (calculatedLength > uint.MaxValue) largeSize = (ulong)calculatedLength;
-            else size = (uint)calculatedLength - 8;
+
+            if (calculatedLength > uint.MaxValue)
+            {
+                largeSize = (ulong)calculatedLength;
+            }
+            else
+            {
+                size = (uint)calculatedLength - 8;
+            }
 
             constrainedStream.PushConstraint(size);
 
             constrainedStream.WriteBEUInt32(size);
             constrainedStream.WriteBEUInt32(Type.FourCC);
-            if (Size == 1) constrainedStream.WriteBEUInt64(largeSize);
-            if (Type.FourCC == 0x75756964) constrainedStream.WriteBytes(Type.UserType.ToByteArray());
+
+            if (Size == 1)
+            {
+                constrainedStream.WriteBEUInt64(largeSize);
+            }
+
+            if (Type.FourCC == uuidType)
+            {
+                constrainedStream.WriteBytes(Type.UserType.ToByteArray());
+            }
 
             SaveToStream(constrainedStream);
-            if (this is ISuperBox) SaveChildrenToStream(constrainedStream);
+
+            if (this is ISuperBox)
+            {
+                SaveChildrenToStream(constrainedStream);
+            }
 
             // TODO: Handle IContentBox properly
             if (this is IContentBox && this.HasContent)
@@ -330,11 +419,15 @@ namespace MatrixIO.IO.Bmff
             }
 
             long remainder = offset + (size == 1 ? (long)largeSize : size) - constrainedStream.Position;
+
             if (remainder > 0)
             {
                 Trace.WriteLine("Undershot by " + remainder + " bytes.  Padding with 0s.", "WARNING");
+
                 for (long i = 0; i < remainder; i++)
+                {
                     constrainedStream.WriteByte(0);
+                }
             }
 
             constrainedStream.PopConstraint();
@@ -343,20 +436,26 @@ namespace MatrixIO.IO.Bmff
         public Stream GetContentStream()
         {
             Stream source = ConstrainedStream.UnwrapStream(_sourceStream);
-            if (!source.CanSeek) throw new FileNotFoundException("Invalid Source Stream in Box.GetContentStream()");
+
+            if (!source.CanSeek)
+            {
+                throw new FileNotFoundException("Invalid Source Stream in Box.GetContentStream()");
+            }
 
             source.Seek((long)ContentOffset, SeekOrigin.Begin);
+
             ConstrainedStream contentStream = ConstrainedStream.WrapStream(source);
+
             contentStream.PushConstraint((long)ContentOffset, (long)ContentSize);
+
             return contentStream;
         }
 
         public override string ToString()
         {
-            if (Type.FourCC == 0x75756964) // return formatted guid for 'uuid'
-                return Type.UserType.ToString("D");
-            else
-                return Type.FourCC;
+            return (Type.FourCC == uuidType)
+                ? Type.UserType.ToString("D")
+                : Type.FourCC.ToString();
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/BoxType.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/BoxType.cs
@@ -79,14 +79,14 @@ namespace MatrixIO.IO.Bmff
 
         public override bool Equals(object obj)
         {
-            return base.Equals(obj) && ((BoxType)obj).UserType == UserType;
+            return obj is BoxType other && other.UserType == UserType;
         }
 
         public override int GetHashCode() => UserType.GetHashCode();
 
         public override string ToString()
         {
-            return FourCC == UUID_FOURCC ? string.Format("uuid({0})", UserType.ToString()) : FourCC.ToString();
+            return FourCC == UUID_FOURCC ? $"uuid({UserType})" : FourCC.ToString();
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/CompactSampleSizeBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/CompactSampleSizeBox.cs
@@ -26,8 +26,8 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.LoadFromStream(stream);
 
-            _Reserved = stream.ReadBEUInt24();
-            _FieldSize = stream.ReadOneByte();
+            _reserved = stream.ReadBEUInt24();
+            _fieldSize = stream.ReadOneByte();
             uint entryCount = stream.ReadBEUInt32();
 
             for (uint i = 0; i < entryCount; i++)
@@ -37,7 +37,9 @@ namespace MatrixIO.IO.Bmff.Boxes
                     byte twoFieldSizes = stream.ReadOneByte();
                     Entries.Add(new CompactSampleSizeEntry((ushort)(twoFieldSizes & 0xFF00 >> 4)));
                     if (i < entryCount)
+                    {
                         Entries.Add(new CompactSampleSizeEntry((ushort)(twoFieldSizes & 0x00FF)));
+                    }
                 }
                 else if (FieldSize == 8)
                     Entries.Add(new CompactSampleSizeEntry(stream.ReadOneByte()));
@@ -50,7 +52,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.SaveToStream(stream);
 
-            stream.WriteBEUInt24(_Reserved);
+            stream.WriteBEUInt24(_reserved);
             stream.WriteByte(FieldSize);
             stream.WriteBEUInt32((uint)Entries.Count);
 
@@ -78,16 +80,20 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public IList<CompactSampleSizeEntry> Entries { get; } = new List<CompactSampleSizeEntry>();
 
-        private uint _Reserved;
+        private uint _reserved;
 
-        private byte _FieldSize;
+        private byte _fieldSize;
         public byte FieldSize
         {
-            get => _FieldSize;
+            get => _fieldSize;
             set
             {
-                if (_FieldSize != 4 && _FieldSize != 8 && _FieldSize != 16) throw new ArgumentOutOfRangeException("FieldSize must be 4, 8 or 16.");
-                _FieldSize = value;
+                if (_fieldSize != 4 && _fieldSize != 8 && _fieldSize != 16)
+                {
+                    throw new ArgumentOutOfRangeException("FieldSize must be 4, 8 or 16.");
+                }
+
+                _fieldSize = value;
             }
         }
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/CompactSampleSizeBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/CompactSampleSizeBox.cs
@@ -61,8 +61,12 @@ namespace MatrixIO.IO.Bmff.Boxes
                 for (int i = 0; i < Entries.Count; i += 2)
                 {
                     byte twoFieldSizes = (byte)((Entries[i].EntrySize & 0x00FF) << 4);
+
                     if (i + 1 < Entries.Count)
+                    {
                         twoFieldSizes |= (byte)(Entries[i].EntrySize & 0x00FF);
+                    }
+
                     stream.WriteByte(twoFieldSizes);
                 }
             }
@@ -71,9 +75,13 @@ namespace MatrixIO.IO.Bmff.Boxes
                 foreach (CompactSampleSizeEntry compactSampleSizeEntry in Entries)
                 {
                     if (FieldSize == 8)
+                    {
                         stream.WriteByte((byte)compactSampleSizeEntry.EntrySize);
+                    }
                     else if (FieldSize == 16)
+                    {
                         stream.WriteBEUInt16(compactSampleSizeEntry.EntrySize);
+                    }
                 }
             }
         }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/CompositionOffsetBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/CompositionOffsetBox.cs
@@ -9,8 +9,15 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("ctts", "Composition Offset Box")]
     public sealed class CompositionOffsetBox : FullBox, ITableBox<CompositionOffsetBox.CompositionOffsetEntry>
     {
-        public CompositionOffsetBox() : base() { }
-        public CompositionOffsetBox(Stream stream) : base(stream) { }
+        public CompositionOffsetBox()
+            : base() { }
+
+        public CompositionOffsetBox(Stream stream) 
+            : base(stream) { }
+
+        public IList<CompositionOffsetEntry> Entries { get; } = new List<CompositionOffsetEntry>();
+
+        public int EntryCount => Entries.Count;
 
         internal override ulong CalculateSize()
         {
@@ -44,10 +51,6 @@ namespace MatrixIO.IO.Bmff.Boxes
                 stream.WriteBEUInt32(CompositionOffsetEntry.SampleOffset);
             }
         }
-
-        public IList<CompositionOffsetEntry> Entries { get; } = new List<CompositionOffsetEntry>();
-
-        public int EntryCount => Entries.Count;
 
         public readonly struct CompositionOffsetEntry
         {

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataEntryUrlBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataEntryUrlBox.cs
@@ -28,7 +28,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.SaveToStream(stream);
 
-            if(!string.IsNullOrEmpty(Location))
+            if (!string.IsNullOrEmpty(Location))
                 stream.WriteUTF8String(Location);
         }
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataEntryUrlBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataEntryUrlBox.cs
@@ -9,8 +9,13 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("url ", "Data Entry Url Box")]
     public sealed class DataEntryUrlBox : FullBox
     {
-        public DataEntryUrlBox() : base() { }
-        public DataEntryUrlBox(Stream stream) : base(stream) { }
+        public DataEntryUrlBox() 
+            : base() { }
+
+        public DataEntryUrlBox(Stream stream) 
+            : base(stream) { }
+
+        public string Location { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -29,9 +34,9 @@ namespace MatrixIO.IO.Bmff.Boxes
             base.SaveToStream(stream);
 
             if (!string.IsNullOrEmpty(Location))
+            {
                 stream.WriteUTF8String(Location);
+            }
         }
-
-        public string Location { get; set; }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataEntryUrnBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataEntryUrnBox.cs
@@ -10,7 +10,13 @@ namespace MatrixIO.IO.Bmff.Boxes
     public sealed class DataEntryUrnBox : FullBox
     {
         public DataEntryUrnBox() : base() { }
-        public DataEntryUrnBox(Stream stream) : base(stream) { }
+
+        public DataEntryUrnBox(Stream stream) 
+            : base(stream) { }
+
+        public string Name { get; set; }
+
+        public string Location { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -32,12 +38,11 @@ namespace MatrixIO.IO.Bmff.Boxes
             base.SaveToStream(stream);
 
             stream.WriteNullTerminatedUTF8String(Name);
+
             if (Location.Length > 0)
+            {
                 stream.WriteUTF8String(Location);
+            }
         }
-
-        public string Name { get; set; }
-
-        public string Location { get; set; }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataEntryUrnBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataEntryUrnBox.cs
@@ -37,6 +37,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         }
 
         public string Name { get; set; }
+
         public string Location { get; set; }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataEntryUrnBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataEntryUrnBox.cs
@@ -14,8 +14,8 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         internal override ulong CalculateSize()
         {
-            return base.CalculateSize() + 
-                (string.IsNullOrEmpty(Name) ? 0 : (ulong)Encoding.UTF8.GetByteCount(Name)) + 1 + 
+            return base.CalculateSize() +
+                (string.IsNullOrEmpty(Name) ? 0 : (ulong)Encoding.UTF8.GetByteCount(Name)) + 1 +
                 (string.IsNullOrEmpty(Location) ? 0 : (ulong)Encoding.UTF8.GetByteCount(Location));
         }
 
@@ -32,7 +32,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             base.SaveToStream(stream);
 
             stream.WriteNullTerminatedUTF8String(Name);
-            if(Location.Length > 0)
+            if (Location.Length > 0)
                 stream.WriteUTF8String(Location);
         }
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataReferenceBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataReferenceBox.cs
@@ -11,8 +11,15 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("dref", "Data Reference Box")]
     public sealed class DataReferenceBox : FullBox, ISuperBox
     {
-        public DataReferenceBox() : base() { }
-        public DataReferenceBox(Stream stream) : base(stream) { }
+        private uint _entryCount;
+
+        public DataReferenceBox()
+            : base() { }
+
+        public DataReferenceBox(Stream stream)
+            : base(stream) { }
+
+        public IList<Box> Children { get; } = new List<Box>();
 
         internal override ulong CalculateSize()
         {
@@ -23,7 +30,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.LoadFromStream(stream);
 
-            _EntryCount = stream.ReadBEUInt32();
+            _entryCount = stream.ReadBEUInt32();
         }
 
         protected override void SaveToStream(Stream stream)
@@ -37,15 +44,11 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.LoadChildrenFromStream(stream);
 
-            if (_EntryCount != Children.Count)
+            if (_entryCount != Children.Count)
             {
                 Trace.WriteLine("DataReferenceBox's EntryCount didn't match the number of children we read.", "WARNING");
             }
         }
-
-        private uint _EntryCount;
-
-        public IList<Box> Children { get; } = new List<Box>();
 
         public IEnumerator<Box> GetEnumerator() => Children.GetEnumerator();
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/EditListBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/EditListBox.cs
@@ -26,7 +26,7 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             for (uint i = 0; i < entryCount; i++)
             {
-                EditListEntry entry = new EditListEntry();
+                var entry = new EditListEntry();
                 if (Version == 1)
                 {
                     entry.SegmentDuration = stream.ReadBEUInt64();

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/FairPlay/DrmAudioStreamBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/FairPlay/DrmAudioStreamBox.cs
@@ -15,12 +15,7 @@ namespace MatrixIO.IO.Bmff.Boxes.FairPlay
 
         public ProtectionSchemeInfoBox ProtectionSchemeInfo
         {
-            get
-            {
-                return (from c in Children
-                        where c is ProtectionSchemeInfoBox
-                        select (ProtectionSchemeInfoBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<ProtectionSchemeInfoBox>().FirstOrDefault();
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/FairPlay/DrmVideoStreamBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/FairPlay/DrmVideoStreamBox.cs
@@ -15,12 +15,7 @@ namespace MatrixIO.IO.Bmff.Boxes.FairPlay
 
         public ProtectionSchemeInfoBox ProtectionSchemeInfo
         {
-            get
-            {
-                return (from c in Children
-                        where c is ProtectionSchemeInfoBox
-                        select (ProtectionSchemeInfoBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<ProtectionSchemeInfoBox>().FirstOrDefault();
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/FairPlay/ProtectedCEA608Box.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/FairPlay/ProtectedCEA608Box.cs
@@ -15,12 +15,7 @@ namespace MatrixIO.IO.Bmff.Boxes.FairPlay
 
         public ProtectionSchemeInfoBox ProtectionSchemeInfo
         {
-            get
-            {
-                return (from c in Children
-                        where c is ProtectionSchemeInfoBox
-                        select (ProtectionSchemeInfoBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<ProtectionSchemeInfoBox>().FirstOrDefault();
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/FileDeliveryItemInformationBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/FileDeliveryItemInformationBox.cs
@@ -30,9 +30,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.SaveToStream(stream);
 
-            EntryCount = (ushort)(from c in Children
-                                  where c is PartitionEntryBox
-                                  select c).Count();
+            EntryCount = (ushort)Children.OfType<PartitionEntryBox>().Count();
 
             stream.WriteBEUInt16(EntryCount);
         }
@@ -47,33 +45,18 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public IEnumerable<PartitionEntryBox> PartitionEntries
         {
-            get
-            {
-                return from c in Children
-                       where c is PartitionEntryBox
-                       select (PartitionEntryBox)c;
-            }
+            get => Children.OfType<PartitionEntryBox>();
         }
 
         /*
         public FileDeliveySessionGroupBox SessionInfo
         {
-            get
-            {
-                return (from c in Children
-                        where c is FDSessionGroupBox
-                        select (FDSessionGroupBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<FDSessionGroupBox>().FirstOrDefault();
         }
 
         public GroupIdToNameBox GroupIdToName
         {
-            get
-            {
-                return (from c in Children
-                        where c is GroupIdToNameBox
-                        select (GroupIdToNameBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<GroupIdToNameBox>().FirstOrDefault();
         }
         */
     }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/FileTypeBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/FileTypeBox.cs
@@ -9,8 +9,12 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("ftyp", "File Type Box")]
     public sealed class FileTypeBox : Box
     {
-        public FileTypeBox() : base() { }
-        public FileTypeBox(Stream stream) : base(stream) { }
+        public FileTypeBox()
+            : base() { }
+
+        public FileTypeBox(Stream stream)
+            : base(stream) { }
+
         public FileTypeBox(FourCC majorBrand, uint minorVersion, FourCC[] compatibleBrands)
             : this()
         {
@@ -21,6 +25,12 @@ namespace MatrixIO.IO.Bmff.Boxes
                 CompatibleBrands.Add(fourCC);
             }
         }
+
+        public FourCC MajorBrand { get; set; }
+
+        public uint MinorVersion { get; set; }
+
+        public IList<FourCC> CompatibleBrands { get; } = new List<FourCC>();
 
         internal override ulong CalculateSize()
         {
@@ -36,6 +46,7 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             ulong remainingBytes = EffectiveSize - CalculateSize();
             ulong numBrands = remainingBytes / 4;
+
             for (ulong i = 0; i < numBrands; i++)
             {
                 CompatibleBrands.Add(new FourCC(stream.ReadBEUInt32()));
@@ -54,36 +65,17 @@ namespace MatrixIO.IO.Bmff.Boxes
             }
         }
 
-        public FourCC MajorBrand { get; set; }
-        public uint MinorVersion { get; set; }
-
-        public IList<FourCC> CompatibleBrands { get; } = new List<FourCC>();
-
         public bool IsCompatibleWith(FourCC brand)
         {
-            if (MajorBrand == brand) return true;
-            if (CompatibleBrands.Contains(brand)) return true;
-            return false;
+            return MajorBrand == brand || CompatibleBrands.Contains(brand);
         }
 
-        public bool IsCompatibleWith(int brand)
-        {
-            return IsCompatibleWith(new FourCC(brand));
-        }
+        public bool IsCompatibleWith(int brand) => IsCompatibleWith(new FourCC(brand));
 
-        public bool IsCompatibleWith(uint brand)
-        {
-            return IsCompatibleWith(new FourCC(brand));
-        }
+        public bool IsCompatibleWith(uint brand) => IsCompatibleWith(new FourCC(brand));
 
-        public bool IsCompatibleWith(string brand)
-        {
-            return IsCompatibleWith(new FourCC(brand));
-        }
+        public bool IsCompatibleWith(string brand) => IsCompatibleWith(new FourCC(brand));
 
-        public bool IsCompatibleWith(byte[] brand)
-        {
-            return IsCompatibleWith(new FourCC(brand));
-        }
+        public bool IsCompatibleWith(byte[] brand) => IsCompatibleWith(new FourCC(brand));
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/HandlerBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/HandlerBox.cs
@@ -10,21 +10,36 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("hdlr", "Handler Reference Box")]
     public sealed class HandlerBox : FullBox
     {
-        public HandlerBox() : base() { }
-        public HandlerBox(Stream stream) : base(stream) { }
+        private uint[] _reserved = new uint[3];
+        private uint _predefined;
+
+        public HandlerBox()
+            : base() { }
+
+        public HandlerBox(Stream stream)
+            : base(stream) { }
+
+        public FourCC HandlerType { get; set; }
+
+        public string Name { get; set; }
 
         internal override ulong CalculateSize()
         {
-            return base.CalculateSize() + 4 + 4 + (4 * (ulong)_Reserved.Length) + (string.IsNullOrEmpty(Name) ? 0 : (ulong)Encoding.UTF8.GetByteCount(Name));
+            return base.CalculateSize() + 4 + 4 + (4 * (ulong)_reserved.Length) + (string.IsNullOrEmpty(Name) ? 0 : (ulong)Encoding.UTF8.GetByteCount(Name));
         }
 
         protected override void LoadFromStream(Stream stream)
         {
             base.LoadFromStream(stream);
 
-            _Predefined = stream.ReadBEUInt32();
+            _predefined = stream.ReadBEUInt32();
             HandlerType = new FourCC(stream.ReadBytes(4));
-            for (int i = 0; i < _Reserved.Length; i++) _Reserved[i] = stream.ReadBEUInt32();
+
+            for (int i = 0; i < _reserved.Length; i++)
+            {
+                _reserved[i] = stream.ReadBEUInt32();
+            }
+
             Name = stream.ReadNullTerminatedUTF8String();
         }
 
@@ -32,18 +47,18 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.SaveToStream(stream);
 
-            stream.WriteBEUInt32(_Predefined);
+            stream.WriteBEUInt32(_predefined);
             stream.WriteBEUInt32(HandlerType);
-            for (int i = 0; i < _Reserved.Length; i++) stream.WriteBEUInt32(_Reserved[i]);
+
+            for (int i = 0; i < _reserved.Length; i++)
+            {
+                stream.WriteBEUInt32(_reserved[i]);
+            }
+
             if (Name != null)
+            {
                 stream.WriteUTF8String(Name);
+            }
         }
-
-        private uint _Predefined;
-        public FourCC HandlerType { get; set; }
-
-        private uint[] _Reserved = new uint[3];
-
-        public string Name { get; set; }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/HintMediaHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/HintMediaHeaderBox.cs
@@ -8,8 +8,21 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("hmhd", "Hint Media Header Box")]
     public sealed class HintMediaHeaderBox : FullBox
     {
-        public HintMediaHeaderBox() : base() { }
-        public HintMediaHeaderBox(Stream stream) : base(stream) { }
+        public HintMediaHeaderBox() 
+            : base() { }
+
+        public HintMediaHeaderBox(Stream stream) 
+            : base(stream) { }
+
+        public ushort MaxProtocolDataUnitSize { get; set; }
+
+        public ushort AverageProtocolDataUnitSize { get; set; }
+
+        public uint MaxBitrate { get; set; }
+
+        public uint AverageBitrate { get; set; }
+
+        private uint Reserved { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -24,7 +37,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             AverageProtocolDataUnitSize = stream.ReadBEUInt16();
             MaxBitrate = stream.ReadBEUInt32();
             AverageBitrate = stream.ReadBEUInt32();
-            _Reserved = stream.ReadBEUInt32();
+            Reserved = stream.ReadBEUInt32();
         }
 
         protected override void SaveToStream(Stream stream)
@@ -35,13 +48,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             stream.WriteBEUInt16(AverageProtocolDataUnitSize);
             stream.WriteBEUInt32(MaxBitrate);
             stream.WriteBEUInt32(AverageBitrate);
-            stream.WriteBEUInt32(_Reserved);
+            stream.WriteBEUInt32(Reserved);
         }
-
-        public ushort MaxProtocolDataUnitSize { get; set; }
-        public ushort AverageProtocolDataUnitSize { get; set; }
-        public uint MaxBitrate { get; set; }
-        public uint AverageBitrate { get; set; }
-        private uint _Reserved;
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/ItemProtectionBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/ItemProtectionBox.cs
@@ -43,12 +43,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         /*
         public IEnumerable<ProtectionSchemeInfoBox> ProtectionInformation
         {
-            get
-            {
-                return from c in Children
-                       where c is ProtectionSchemeInfoBox
-                       select (ProtectionSchemeInfoBox)c;
-            }
+            get => Children.OfType<ProtectionSchemeInfoBox>();
         }
         */
     }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/ItemProtectionBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/ItemProtectionBox.cs
@@ -18,14 +18,14 @@ namespace MatrixIO.IO.Bmff.Boxes
             return base.CalculateSize() + 2;
         }
 
-        protected override void LoadFromStream(System.IO.Stream stream)
+        protected override void LoadFromStream(Stream stream)
         {
             base.LoadFromStream(stream);
 
             ProtectionCount = stream.ReadBEUInt16();
         }
 
-        protected override void SaveToStream(System.IO.Stream stream)
+        protected override void SaveToStream(Stream stream)
         {
             base.SaveToStream(stream);
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/Jp2/BitsPerComponentBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/Jp2/BitsPerComponentBox.cs
@@ -9,12 +9,19 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("bpcc", "Bits Per Component Box")]
     public sealed class BitsPerComponentBox : Box, ITableBox<BitsPerComponentBox.ComponentBitsEntry>
     {
-        public BitsPerComponentBox() : base() { }
-        public BitsPerComponentBox(Stream stream) : base(stream) { }
+        public BitsPerComponentBox() 
+            : base() { }
+
+        public BitsPerComponentBox(Stream stream) 
+            : base(stream) { }
+
+        public IList<ComponentBitsEntry> Entries { get; } = new List<ComponentBitsEntry>();
+
+        public int EntryCount => Entries.Count;
 
         internal override ulong CalculateSize()
         {
-            return base.CalculateSize() + (ulong)_Entries.Count;
+            return base.CalculateSize() + (ulong)Entries.Count;
         }
 
         protected override void LoadFromStream(Stream stream)
@@ -25,7 +32,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             while (stream.Position < (long)(Offset + EffectiveSize))
             {
                 byte b = stream.ReadOneByte();
-                _Entries.Add(new ComponentBitsEntry(b));
+                Entries.Add(new ComponentBitsEntry(b));
             }
         }
 
@@ -34,17 +41,11 @@ namespace MatrixIO.IO.Bmff.Boxes
             base.SaveToStream(stream);
 
             // TODO: Convert to byte[] and write all at once.
-            foreach (ComponentBitsEntry entry in _Entries)
+            foreach (ComponentBitsEntry entry in Entries)
             {
                 stream.WriteOneByte(entry.ComponentBits);
             }
         }
-
-        private IList<ComponentBitsEntry> _Entries = new List<ComponentBitsEntry>();
-
-        public IList<ComponentBitsEntry> Entries => _Entries;
-
-        public int EntryCount => _Entries.Count;
 
         public readonly struct ComponentBitsEntry
         {
@@ -59,6 +60,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             {
                 return entry.ComponentBits;
             }
+
             public static implicit operator ComponentBitsEntry(byte componentBits)
             {
                 return new ComponentBitsEntry(componentBits);

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/Jp2/ImageHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/Jp2/ImageHeaderBox.cs
@@ -8,8 +8,52 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("ihdr", "Image Header Box")]
     public sealed class ImageHeaderBox : Box
     {
-        public ImageHeaderBox() : base() { }
-        public ImageHeaderBox(Stream stream) : base(stream) { }
+        private uint _height;
+        private uint _width;
+        private ushort _numberOfComponents;
+        private byte _isUnknownColorSpace;
+        private byte _isIntellectualProperty;
+
+        public ImageHeaderBox()
+            : base() { }
+
+        public ImageHeaderBox(Stream stream)
+            : base(stream) { }
+
+        public long Height
+        {
+            get => _height;
+            set => _height = checked((uint)value);
+        }
+
+        public long Width
+        {
+            get => _width;
+            set => _width = checked((uint)value);
+        }
+
+        public int NumberOfComponents
+        {
+            get => _numberOfComponents;
+            set => _numberOfComponents = checked((ushort)value);
+        }
+
+        public byte BitsPerComponent { get; set; }
+
+        // Note: default value defined in 15444-1 Annex I
+        public byte CompressionType { get; set; } = 7;
+
+        public bool IsUnknownColorspace
+        {
+            get => _isUnknownColorSpace > 0;
+            set => _isUnknownColorSpace = value ? (byte)0x01 : (byte)0x00;
+        }
+
+        public bool IsIntellectualProperty
+        {
+            get => _isIntellectualProperty > 0;
+            set => _isIntellectualProperty = value ? (byte)0x01 : (byte)0x00;
+        }
 
         internal override ulong CalculateSize()
         {
@@ -40,46 +84,6 @@ namespace MatrixIO.IO.Bmff.Boxes
             stream.WriteOneByte(CompressionType);
             stream.WriteOneByte(_isUnknownColorSpace);
             stream.WriteOneByte(_isIntellectualProperty);
-        }
-
-        private uint _height;
-        public long Height
-        {
-            get => _height;
-            set => _height = checked((uint)value);
-        }
-
-        private uint _width;
-        public long Width
-        {
-            get => _width;
-            set => _width = checked((uint)value);
-        }
-
-        private ushort _numberOfComponents;
-        public int NumberOfComponents
-        {
-            get => _numberOfComponents; set => 
-                _numberOfComponents = checked((ushort)value);
-        }
-
-        public byte BitsPerComponent { get; set; }
-
-        // Note: default value defined in 15444-1 Annex I
-        public byte CompressionType { get; set; } = 7;
-
-        private byte _isUnknownColorSpace;
-        public bool IsUnknownColorspace
-        {
-            get => _isUnknownColorSpace > 0;
-            set => _isUnknownColorSpace = value ? (byte)0x01 : (byte)0x00;
-        }
-
-        private byte _isIntellectualProperty;
-        public bool IsIntellectualProperty
-        {
-            get => _isIntellectualProperty > 0;
-            set => _isIntellectualProperty = value ? (byte)0x01 : (byte)0x00;
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/Jp2/ImageHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/Jp2/ImageHeaderBox.cs
@@ -20,46 +20,66 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.LoadFromStream(stream);
 
-            _Height = stream.ReadBEUInt32();
-            _Width = stream.ReadBEUInt32();
-            _NumberOfComponents = stream.ReadBEUInt16();
+            _height = stream.ReadBEUInt32();
+            _width = stream.ReadBEUInt32();
+            _numberOfComponents = stream.ReadBEUInt16();
             BitsPerComponent = stream.ReadOneByte();
-            _CompressionType = stream.ReadOneByte();
-            _IsUnknownColorspace = stream.ReadOneByte();
-            _IsIntellectualProperty = stream.ReadOneByte();
+            CompressionType = stream.ReadOneByte();
+            _isUnknownColorSpace = stream.ReadOneByte();
+            _isIntellectualProperty = stream.ReadOneByte();
         }
 
         protected override void SaveToStream(Stream stream)
         {
             base.SaveToStream(stream);
 
-            stream.WriteBEUInt32(_Height);
-            stream.WriteBEUInt32(_Width);
-            stream.WriteBEUInt16(_NumberOfComponents);
+            stream.WriteBEUInt32(_height);
+            stream.WriteBEUInt32(_width);
+            stream.WriteBEUInt16(_numberOfComponents);
             stream.WriteOneByte(BitsPerComponent);
-            stream.WriteOneByte(_CompressionType);
-            stream.WriteOneByte(_IsUnknownColorspace);
-            stream.WriteOneByte(_IsIntellectualProperty);
+            stream.WriteOneByte(CompressionType);
+            stream.WriteOneByte(_isUnknownColorSpace);
+            stream.WriteOneByte(_isIntellectualProperty);
         }
 
-        private uint _Height;
-        public long Height { get { return _Height; } set { _Height = checked((uint)value); } }
+        private uint _height;
+        public long Height
+        {
+            get => _height;
+            set => _height = checked((uint)value);
+        }
 
-        private uint _Width;
-        public long Width { get { return _Width; } set { _Width = checked((uint)value); } }
+        private uint _width;
+        public long Width
+        {
+            get => _width;
+            set => _width = checked((uint)value);
+        }
 
-        private ushort _NumberOfComponents;
-        public int NumberOfComponents { get { return _NumberOfComponents; } set { _NumberOfComponents = checked((ushort)value); } }
+        private ushort _numberOfComponents;
+        public int NumberOfComponents
+        {
+            get => _numberOfComponents; set => 
+                _numberOfComponents = checked((ushort)value);
+        }
 
         public byte BitsPerComponent { get; set; }
 
-        private byte _CompressionType = 7; // Default value defined in 15444-1 Annex I
-        public byte CompressionType { get { return _CompressionType; } set { _CompressionType = value; } }
+        // Note: default value defined in 15444-1 Annex I
+        public byte CompressionType { get; set; } = 7;
 
-        private byte _IsUnknownColorspace;
-        public bool IsUnknownColorspace { get { return _IsUnknownColorspace > 0; } set { _IsUnknownColorspace = value ? (byte)0x01 : (byte)0x00; } }
+        private byte _isUnknownColorSpace;
+        public bool IsUnknownColorspace
+        {
+            get => _isUnknownColorSpace > 0;
+            set => _isUnknownColorSpace = value ? (byte)0x01 : (byte)0x00;
+        }
 
-        private byte _IsIntellectualProperty;
-        public bool IsIntellectualProperty { get { return _IsIntellectualProperty > 0; } set { _IsIntellectualProperty = value ? (byte)0x01 : (byte)0x00; } }
+        private byte _isIntellectualProperty;
+        public bool IsIntellectualProperty
+        {
+            get => _isIntellectualProperty > 0;
+            set => _isIntellectualProperty = value ? (byte)0x01 : (byte)0x00;
+        }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MediaBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MediaBox.cs
@@ -9,7 +9,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// A common base structure is used to contain general metadata, called the meta box.
     /// </summary>
     [Box("mdia", "Media Box")]
-    public class MediaBox : Box, ISuperBox
+    public sealed class MediaBox : Box, ISuperBox
     {
         public MediaBox() : base() { }
         public MediaBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MediaHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MediaHeaderBox.cs
@@ -10,8 +10,29 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("mdhd", "Media Header Box")]
     public sealed class MediaHeaderBox : FullBox
     {
-        public MediaHeaderBox() : base() { }
-        public MediaHeaderBox(Stream stream) : base(stream) { }
+        private const ushort CHARBASE = 0x0060;
+        private const ushort CHARMASK1 = 0x7C00;
+        private const ushort CHARMASK2 = 0x03E0;
+        private const ushort CHARMASK3 = 0x001F;
+
+        public MediaHeaderBox()
+            : base() { }
+
+        public MediaHeaderBox(Stream stream)
+            : base(stream) { }
+
+        public DateTime CreationTime { get; set; }
+
+        public DateTime ModificationTime { get; set; }
+
+        public uint TimeScale { get; set; }
+
+        public ulong Duration { get; set; }
+
+        // TODO: Validate this on set.
+        public string Language { get; set; }
+
+        public ushort Predefined { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -64,34 +85,30 @@ namespace MatrixIO.IO.Bmff.Boxes
             stream.WriteBEUInt16(Predefined);
         }
 
-        public DateTime CreationTime { get; set; }
-        public DateTime ModificationTime { get; set; }
-        public uint TimeScale { get; set; }
-        public ulong Duration { get; set; }
 
-        // TODO: Validate this on set.
-        public string Language { get; set; }
-        public ushort Predefined { get; set; }
-
-        private const ushort CHARBASE = 0x0060;
-        private const ushort CHARMASK1 = 0x7C00;
-        private const ushort CHARMASK2 = 0x03E0;
-        private const ushort CHARMASK3 = 0x001F;
-
-        internal ushort ConvertThreeLetterLanguageCode(string language)
+        internal static ushort ConvertThreeLetterLanguageCode(string language)
         {
             byte[] langBytes = Encoding.UTF8.GetBytes(language);
-            if (langBytes.Length != 3) throw new ArgumentOutOfRangeException();
-            return (ushort)((((langBytes[0] - CHARBASE) << 10) & CHARMASK1) | (((langBytes[1] - CHARBASE) << 5) & CHARMASK2) | (((langBytes[2] - CHARBASE) & CHARMASK3)));
-        }
-        internal string ConvertThreeLetterLanguageCode(ushort language)
-        {
-            byte[] langBytes = new byte[3];
-            langBytes[0] = (byte)(((language & CHARMASK1) >> 10) + CHARBASE);
-            langBytes[1] = (byte)(((language & CHARMASK2) >> 5) + CHARBASE);
-            langBytes[2] = (byte)((language & CHARMASK3) + CHARBASE);
-            return Encoding.UTF8.GetString(langBytes, 0, langBytes.Length);
+
+            if (langBytes.Length != 3)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            return (ushort)((((langBytes[0] - CHARBASE) << 10) & CHARMASK1)
+                | (((langBytes[1] - CHARBASE) << 5) & CHARMASK2)
+                | (((langBytes[2] - CHARBASE) & CHARMASK3)));
         }
 
+        internal static string ConvertThreeLetterLanguageCode(ushort language)
+        {
+            byte[] langBytes = new byte[3] {
+                (byte)(((language & CHARMASK1) >> 10) + CHARBASE),
+                (byte)(((language & CHARMASK2) >> 5) + CHARBASE),
+                (byte)((language & CHARMASK3) + CHARBASE)
+            };
+
+            return Encoding.UTF8.GetString(langBytes, 0, langBytes.Length);
+        }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MediaHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MediaHeaderBox.cs
@@ -8,7 +8,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Media Header Box ("mdhd")
     /// </summary>
     [Box("mdhd", "Media Header Box")]
-    public class MediaHeaderBox : FullBox
+    public sealed class MediaHeaderBox : FullBox
     {
         public MediaHeaderBox() : base() { }
         public MediaHeaderBox(Stream stream) : base(stream) { }
@@ -82,7 +82,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             byte[] langBytes = Encoding.UTF8.GetBytes(language);
             if (langBytes.Length != 3) throw new ArgumentOutOfRangeException();
-            return (ushort)((((langBytes[0]-CHARBASE) << 10) & CHARMASK1) | (((langBytes[1]-CHARBASE) << 5) & CHARMASK2) | (((langBytes[2]-CHARBASE) & CHARMASK3)));
+            return (ushort)((((langBytes[0] - CHARBASE) << 10) & CHARMASK1) | (((langBytes[1] - CHARBASE) << 5) & CHARMASK2) | (((langBytes[2] - CHARBASE) & CHARMASK3)));
         }
         internal string ConvertThreeLetterLanguageCode(ushort language)
         {

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MetaBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MetaBox.cs
@@ -25,71 +25,41 @@ namespace MatrixIO.IO.Bmff.Boxes
         /* TODO: Support standard sub-boxes!
         public HandlerBox TheHandler
         {
-            get
-            {
-                return (from c in _Children
-                        where c is HandlerBox
-                        select (HandlerBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<HandlerBox>().FirstOrDefault();
         }
+
         public PrimaryItemBox PrimaryResource
         {
-            get
-            {
-                return (from c in _Children
-                        where c is PrimaryItemBox
-                        select (PrimaryItemBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<PrimaryItemBox>().FirstOrDefault();
         }
         */
+
         public DataInformationBox FileLocations
         {
-            get
-            {
-                return (from c in Children
-                        where c is DataInformationBox
-                        select (DataInformationBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<DataInformationBox>().FirstOrDefault();
         }
+
         /*
         public ItemLocationBox ItemLocations
         {
-            get
-            {
-                return (from c in _Children
-                        where c is ItemLocationBox
-                        select (ItemLocationBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<ItemLocationBox>().FirstOrDefault();
         }
         */
+
         public ItemProtectionBox Protections
         {
-            get
-            {
-                return (from c in Children
-                        where c is ItemProtectionBox
-                        select (ItemProtectionBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<ItemProtectionBox>().FirstOrDefault();
         }
+
         /*
         public ItemInfoBox ItemInfos
         {
-            get
-            {
-                return (from c in _Children
-                        where c is ItemInfonBox
-                        select (ItemInfoBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<ItemInfoBox>().FirstOrDefault();      
         }
 
         public IPMPControlBox IPMPControl
         {
-            get
-            {
-                return (from c in _Children
-                        where c is IPMPControlBox
-                        select (IPMPControlBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<IPMPControlBox>().FirstOrDefault();
         }
         */
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieBox.cs
@@ -8,7 +8,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Movie Box ("moov")
     /// </summary>
     [Box("moov", "Movie Box")]
-    public class MovieBox : Box, ISuperBox
+    public sealed class MovieBox : Box, ISuperBox
     {
         public MovieBox() : base() { }
         public MovieBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieDataBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieDataBox.cs
@@ -7,7 +7,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Movie Data Box ("mdat")
     /// </summary>
     [Box("mdat", "Movie Data Box")]
-    public class MovieDataBox : Box, IContentBox
+    public sealed class MovieDataBox : Box, IContentBox
     {
         public MovieDataBox() : base() { }
         /// <summary>

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieExtendsBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieExtendsBox.cs
@@ -8,7 +8,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Movie Extends Box ("mvex")
     /// </summary>
     [Box("mvex", "Movie Extends Box")]
-    public class MovieExtendsBox : Box, ISuperBox
+    public sealed class MovieExtendsBox : Box, ISuperBox
     {
         public MovieExtendsBox() : base() { }
         public MovieExtendsBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieExtendsHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieExtendsHeaderBox.cs
@@ -8,8 +8,13 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("mehd", "Movie Extends Header Box")]
     public sealed class MovieExtendsHeaderBox : FullBox
     {
-        public MovieExtendsHeaderBox() : base() { }
-        public MovieExtendsHeaderBox(Stream stream) : base(stream) { }
+        public MovieExtendsHeaderBox()
+            : base() { }
+
+        public MovieExtendsHeaderBox(Stream stream) 
+            : base(stream) { }
+
+        public ulong FragmentDuration { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -41,7 +46,5 @@ namespace MatrixIO.IO.Bmff.Boxes
                 stream.WriteBEUInt32((uint)FragmentDuration);
             }
         }
-
-        public ulong FragmentDuration { get; set; }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieExtendsHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieExtendsHeaderBox.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace MatrixIO.IO.Bmff.Boxes
 {
@@ -21,18 +20,26 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.LoadFromStream(stream);
 
-            if (Version == 1) FragmentDuration = stream.ReadBEUInt64();
-            else FragmentDuration = (ulong)stream.ReadBEInt32();
+            FragmentDuration = (Version == 1) ? stream.ReadBEUInt64() : (ulong)stream.ReadBEInt32();
         }
 
         protected override void SaveToStream(Stream stream)
         {
-            if(FragmentDuration > UInt32.MaxValue) Version = 1;
+            if (FragmentDuration > uint.MaxValue)
+            {
+                Version = 1;
+            }
 
             base.SaveToStream(stream);
 
-            if (Version == 1) stream.WriteBEUInt64(FragmentDuration);
-            else stream.WriteBEUInt32((uint)FragmentDuration);
+            if (Version == 1)
+            {
+                stream.WriteBEUInt64(FragmentDuration);
+            }
+            else
+            {
+                stream.WriteBEUInt32((uint)FragmentDuration);
+            }
         }
 
         public ulong FragmentDuration { get; set; }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieExtendsHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieExtendsHeaderBox.cs
@@ -7,7 +7,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Movie Extends Header Box ("mehd")
     /// </summary>
     [Box("mehd", "Movie Extends Header Box")]
-    public class MovieExtendsHeaderBox : FullBox
+    public sealed class MovieExtendsHeaderBox : FullBox
     {
         public MovieExtendsHeaderBox() : base() { }
         public MovieExtendsHeaderBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentBox.cs
@@ -8,7 +8,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Movie Fragment Box ("moof")
     /// </summary>
     [Box("moof", "Movie Fragment Box")]
-    public class MovieFragmentBox : Box, ISuperBox
+    public sealed class MovieFragmentBox : Box, ISuperBox
     {
         public MovieFragmentBox() : base() { }
         public MovieFragmentBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentHeaderBox.cs
@@ -8,8 +8,13 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("mfhd", "Movie Fragment Header Box")]
     public sealed class MovieFragmentHeaderBox : FullBox
     {
-        public MovieFragmentHeaderBox() : base() { }
-        public MovieFragmentHeaderBox(Stream stream) : base(stream) { }
+        public MovieFragmentHeaderBox() 
+            : base() { }
+
+        public MovieFragmentHeaderBox(Stream stream) 
+            : base(stream) { }
+
+        public uint SequenceNumber { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -29,6 +34,5 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             stream.WriteBEUInt32(SequenceNumber);
         }
-        public uint SequenceNumber { get; set; }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentHeaderBox.cs
@@ -6,7 +6,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Movie Fragment Header Box ("mfhd")
     /// </summary>
     [Box("mfhd", "Movie Fragment Header Box")]
-    public class MovieFragmentHeaderBox : FullBox
+    public sealed class MovieFragmentHeaderBox : FullBox
     {
         public MovieFragmentHeaderBox() : base() { }
         public MovieFragmentHeaderBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentRandomAccessBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentRandomAccessBox.cs
@@ -9,7 +9,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Movie Fragment Random Access Box ("mfra")
     /// </summary>
     [Box("mfra", "Movie Fragment Random Access Box")]
-    public class MovieFragmentRandomAccessBox : Box, ISuperBox
+    public sealed class MovieFragmentRandomAccessBox : Box, ISuperBox
     {
         public MovieFragmentRandomAccessBox() : base() { }
         public MovieFragmentRandomAccessBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentRandomAccessBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentRandomAccessBox.cs
@@ -25,8 +25,8 @@ namespace MatrixIO.IO.Bmff.Boxes
             get
             {
                 return from c in Children
-                        where c is TrackFragmentRandomAccessBox
-                        select (TrackFragmentRandomAccessBox)c;
+                       where c is TrackFragmentRandomAccessBox
+                       select (TrackFragmentRandomAccessBox)c;
             }
         }
 
@@ -36,7 +36,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             {
                 return (from c in Children
                         where c is MovieFragmentRandomAccessOffsetBox
-                        select (MovieFragmentRandomAccessOffsetBox) c).LastOrDefault();
+                        select (MovieFragmentRandomAccessOffsetBox)c).LastOrDefault();
             }
         }
     }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentRandomAccessBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentRandomAccessBox.cs
@@ -22,22 +22,12 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public IEnumerable<TrackFragmentRandomAccessBox> TrackFragmentRandomAccessBoxes
         {
-            get
-            {
-                return from c in Children
-                       where c is TrackFragmentRandomAccessBox
-                       select (TrackFragmentRandomAccessBox)c;
-            }
+            get => Children.OfType<TrackFragmentRandomAccessBox>();
         }
 
         public MovieFragmentRandomAccessOffsetBox MovieFragmentRandomAccessOffsetBox
         {
-            get
-            {
-                return (from c in Children
-                        where c is MovieFragmentRandomAccessOffsetBox
-                        select (MovieFragmentRandomAccessOffsetBox)c).LastOrDefault();
-            }
+            get => Children.OfType<MovieFragmentRandomAccessOffsetBox>().LastOrDefault();
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentRandomAccessOffsetBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentRandomAccessOffsetBox.cs
@@ -8,8 +8,13 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("mfro", "Movie Fragment Random Access Offset Box")]
     public sealed class MovieFragmentRandomAccessOffsetBox : FullBox
     {
-        public MovieFragmentRandomAccessOffsetBox() : base() { }
-        public MovieFragmentRandomAccessOffsetBox(Stream stream) : base(stream) { }
+        public MovieFragmentRandomAccessOffsetBox() 
+            : base() { }
+
+        public MovieFragmentRandomAccessOffsetBox(Stream stream) 
+            : base(stream) { }
+
+        public uint MfraSize { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -29,7 +34,5 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             stream.WriteBEUInt32(MfraSize);
         }
-
-        public uint MfraSize { get; set; }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentRandomAccessOffsetBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieFragmentRandomAccessOffsetBox.cs
@@ -6,7 +6,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Movie Fragment Random Access Offset Box ("mfro")
     /// </summary>
     [Box("mfro", "Movie Fragment Random Access Offset Box")]
-    public class MovieFragmentRandomAccessOffsetBox : FullBox
+    public sealed class MovieFragmentRandomAccessOffsetBox : FullBox
     {
         public MovieFragmentRandomAccessOffsetBox() : base() { }
         public MovieFragmentRandomAccessOffsetBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieHeaderBox.cs
@@ -9,13 +9,16 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("mvhd", "Movie Header Box")]
     public sealed class MovieHeaderBox : FullBox
     {
-        public MovieHeaderBox() : base()
+        public MovieHeaderBox()
+            : base()
         {
             _rate = 0x00010000; // 1.0 normal rate
             _volume = 0x0100; // 1.0 full volume
             Matrix = new int[] { 0x00010000, 0, 0, 0, 0x00010000, 0, 0, 0, 0x40000000 }; // Unity Matrix
         }
-        public MovieHeaderBox(Stream stream) : base(stream) { }
+
+        public MovieHeaderBox(Stream stream)
+            : base(stream) { }
 
         internal override ulong CalculateSize()
         {
@@ -29,15 +32,15 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             if (Version == 1)
             {
-                _CreationTime = stream.ReadBEUInt64();
-                _ModificationTime = stream.ReadBEUInt64();
+                _creationTime = stream.ReadBEUInt64();
+                _modificationTime = stream.ReadBEUInt64();
                 TimeScale = stream.ReadBEUInt32();
                 Duration = stream.ReadBEUInt64();
             }
             else // if(Version == 0)
             {
-                _CreationTime = stream.ReadBEUInt32();
-                _ModificationTime = stream.ReadBEUInt32();
+                _creationTime = stream.ReadBEUInt32();
+                _modificationTime = stream.ReadBEUInt32();
                 TimeScale = stream.ReadBEUInt32();
                 Duration = stream.ReadBEUInt32();
             }
@@ -53,8 +56,8 @@ namespace MatrixIO.IO.Bmff.Boxes
         protected override void SaveToStream(Stream stream)
         {
             if (Version == 0 &&
-                (_CreationTime > uint.MaxValue ||
-                _ModificationTime > uint.MaxValue ||
+                (_creationTime > uint.MaxValue ||
+                _modificationTime > uint.MaxValue ||
                 Duration > uint.MaxValue))
             {
                 Version = 1;
@@ -64,15 +67,15 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             if (Version == 1)
             {
-                stream.WriteBEUInt64(_CreationTime);
-                stream.WriteBEUInt64(_ModificationTime);
+                stream.WriteBEUInt64(_creationTime);
+                stream.WriteBEUInt64(_modificationTime);
                 stream.WriteBEUInt32(TimeScale);
                 stream.WriteBEUInt64(Duration);
             }
             else // if(Version == 0)
             {
-                stream.WriteBEUInt32(checked((uint)_CreationTime));
-                stream.WriteBEUInt32(checked((uint)_ModificationTime));
+                stream.WriteBEUInt32(checked((uint)_creationTime));
+                stream.WriteBEUInt32(checked((uint)_modificationTime));
                 stream.WriteBEUInt32(TimeScale);
                 stream.WriteBEUInt32(checked((uint)Duration));
             }
@@ -84,18 +87,18 @@ namespace MatrixIO.IO.Bmff.Boxes
             stream.WriteBEUInt32(NextTrackID);
         }
 
-        private ulong _CreationTime;
+        private ulong _creationTime;
         public DateTime CreationTime
         {
-            get => Convert1904Time(_CreationTime);
-            set => _CreationTime = Convert1904Time(value);
+            get => Convert1904Time(_creationTime);
+            set => _creationTime = Convert1904Time(value);
         }
 
-        private ulong _ModificationTime;
+        private ulong _modificationTime;
         public DateTime ModificationTime
         {
-            get => Convert1904Time(_ModificationTime);
-            set => _ModificationTime = Convert1904Time(value);
+            get => Convert1904Time(_modificationTime);
+            set => _modificationTime = Convert1904Time(value);
         }
 
         public uint TimeScale { get; set; }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/MovieHeaderBox.cs
@@ -9,6 +9,11 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("mvhd", "Movie Header Box")]
     public sealed class MovieHeaderBox : FullBox
     {
+        private ulong _creationTime;
+        private ulong _modificationTime;
+        private int _rate;
+        private short _volume;
+
         public MovieHeaderBox()
             : base()
         {
@@ -19,6 +24,42 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public MovieHeaderBox(Stream stream)
             : base(stream) { }
+
+        public DateTime CreationTime
+        {
+            get => Convert1904Time(_creationTime);
+            set => _creationTime = Convert1904Time(value);
+        }
+
+        public DateTime ModificationTime
+        {
+            get => Convert1904Time(_modificationTime);
+            set => _modificationTime = Convert1904Time(value);
+        }
+
+        public uint TimeScale { get; set; }
+
+        public ulong Duration { get; set; }
+
+        public double Rate
+        {
+            get => (double)_rate / ((int)ushort.MaxValue + 1);
+            set => _rate = checked((int)Math.Round(value * ((int)short.MaxValue + 1)));
+        }
+
+        public double Volume
+        {
+            get => (double)_volume / ((int)byte.MaxValue + 1);
+            set => _volume = checked((short)Math.Round(value * ((int)byte.MaxValue + 1)));
+        }
+
+        public byte[] Reserved { get; private set; }
+
+        public int[] Matrix { get; private set; }
+
+        public byte[] PreDefined { get; private set; }
+
+        public uint NextTrackID { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -86,46 +127,6 @@ namespace MatrixIO.IO.Bmff.Boxes
             stream.WriteBytes(PreDefined);
             stream.WriteBEUInt32(NextTrackID);
         }
-
-        private ulong _creationTime;
-        public DateTime CreationTime
-        {
-            get => Convert1904Time(_creationTime);
-            set => _creationTime = Convert1904Time(value);
-        }
-
-        private ulong _modificationTime;
-        public DateTime ModificationTime
-        {
-            get => Convert1904Time(_modificationTime);
-            set => _modificationTime = Convert1904Time(value);
-        }
-
-        public uint TimeScale { get; set; }
-
-        public ulong Duration { get; set; }
-
-        private int _rate;
-        public double Rate
-        {
-            get => (double)_rate / ((int)ushort.MaxValue + 1);
-            set => _rate = checked((int)Math.Round(value * ((int)short.MaxValue + 1)));
-        }
-
-        private short _volume;
-        public double Volume
-        {
-            get => (double)_volume / ((int)byte.MaxValue + 1);
-            set => _volume = checked((short)Math.Round(value * ((int)byte.MaxValue + 1)));
-        }
-
-        public byte[] Reserved { get; private set; }
-
-        public int[] Matrix { get; private set; }
-
-        public byte[] PreDefined { get; private set; }
-
-        public uint NextTrackID { get; set; }
 
         internal static readonly DateTime _1904BaseTime = new DateTime(1904, 1, 1);
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/NullMediaHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/NullMediaHeaderBox.cs
@@ -6,7 +6,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Null Media Header Box ("nmhd")
     /// </summary>
     [Box("nmhd", "Null Media Header Box")]
-    public class NullMediaHeaderBox : FullBox
+    public sealed class NullMediaHeaderBox : FullBox
     {
         public NullMediaHeaderBox() : base() { }
         public NullMediaHeaderBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/OriginalFormatBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/OriginalFormatBox.cs
@@ -8,8 +8,13 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("frma", "Original Format Box")]
     public sealed class OriginalFormatBox : Box
     {
-        public OriginalFormatBox() : base() { }
-        public OriginalFormatBox(Stream stream) : base(stream) { }
+        public OriginalFormatBox() 
+            : base() { }
+
+        public OriginalFormatBox(Stream stream) 
+            : base(stream) { }
+
+        public FourCC DataFormat { get; set; }
 
         protected override void LoadFromStream(Stream stream)
         {
@@ -24,7 +29,5 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             stream.WriteBEUInt32(DataFormat);
         }
-
-        public FourCC DataFormat { get; set; }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/OriginalFormatBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/OriginalFormatBox.cs
@@ -6,7 +6,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Original Format Box ("frma")
     /// </summary>
     [Box("frma", "Original Format Box")]
-    public class OriginalFormatBox : Box
+    public sealed class OriginalFormatBox : Box
     {
         public OriginalFormatBox() : base() { }
         public OriginalFormatBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/PartitionEntryBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/PartitionEntryBox.cs
@@ -8,7 +8,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Partition Entry Box ("paen")
     /// </summary>
     [Box("paen", "Partition Entry Box")]
-    public class PartitionEntryBox : Box, ISuperBox
+    public sealed class PartitionEntryBox : Box, ISuperBox
     {
         public PartitionEntryBox() : base() { }
         public PartitionEntryBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/PartitionEntryBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/PartitionEntryBox.cs
@@ -23,16 +23,13 @@ namespace MatrixIO.IO.Bmff.Boxes
         /*
         public FilePartitionBox BlocksAndSymbols
         {
-            get
-            {
-                return (from c in Children
-                        where c is FilePartitionBox
-                        select (FilePartitionBox)c).FirstOrDefault();
-            }
+             get => Children.OfType<FilePartitionBox>().FirstOrDefault();
         }
 
         public FECReservoirBox FECSymbolLocations
         {
+             get => Children.OfType<FilePartitionBox>().FirstOrDefault();
+
             get
             {
                 return (from c in Children

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/PartitionEntryBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/PartitionEntryBox.cs
@@ -28,14 +28,7 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public FECReservoirBox FECSymbolLocations
         {
-             get => Children.OfType<FilePartitionBox>().FirstOrDefault();
-
-            get
-            {
-                return (from c in Children
-                        where c is FECReservoirBox
-                        select (FECReservoirBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<FECReservoirBox>().FirstOrDefault();
         }
         */
     }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/ProtectionSchemeInfoBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/ProtectionSchemeInfoBox.cs
@@ -9,7 +9,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Protection Scheme Info Box ("sinf")
     /// </summary>
     [Box("sinf", "Protection Scheme Info Box")]
-    public class ProtectionSchemeInfoBox : Box, ISuperBox
+    public sealed class ProtectionSchemeInfoBox : Box, ISuperBox
     {
         public ProtectionSchemeInfoBox() : base() { }
         public ProtectionSchemeInfoBox(Stream stream) : base(stream) { }
@@ -18,36 +18,22 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public IEnumerator<Box> GetEnumerator() => Children.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator()=> Children.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => Children.GetEnumerator();
 
         public OriginalFormatBox OriginalFormat
         {
-            get
-            {
-                return (from c in Children
-                       where c is OriginalFormatBox
-                       select (OriginalFormatBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<OriginalFormatBox>().FirstOrDefault();
         }
 
         /*
         public SchemeTypeBox SchemeType
         {
-            get
-            {
-                return (from c in Children
-                        where c is SchemeTypeBox
-                        select (SchemeTypeBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<SchemeTypeBox>().FirstOrDefault();
         }
+
         public SchemeInformationBox Info
         {
-            get
-            {
-                return (from c in Children
-                        where c is SchemeInformationBox
-                        select (SchemeInformationBox)c).FirstOrDefault();
-            }
+            get => Children.OfType<SchemeInformationBox>().FirstOrDefault();
         }
         */
     }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/QuickTime/DataCompressionBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/QuickTime/DataCompressionBox.cs
@@ -10,8 +10,13 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("dcom", "Data Compression Atom")]
     public sealed class DataCompressionBox : Box
     {
-        public DataCompressionBox() : base() { }
-        public DataCompressionBox(Stream stream) : base(stream) { }
+        public DataCompressionBox()
+            : base() { }
+
+        public DataCompressionBox(Stream stream)
+            : base(stream) { }
+
+        public FourCC Format { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -31,7 +36,5 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             stream.WriteBytes(Format.GetBytes());
         }
-
-        public FourCC Format { get; set; }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/QuickTime/DataEntryAliasBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/QuickTime/DataEntryAliasBox.cs
@@ -9,8 +9,13 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("alis", "Data Entry Alias Atom")]
     public sealed class DataEntryAliasBox : FullBox
     {
-        public DataEntryAliasBox() : base() { }
-        public DataEntryAliasBox(Stream stream) : base(stream) { }
+        public DataEntryAliasBox()
+            : base() { }
+
+        public DataEntryAliasBox(Stream stream)
+            : base(stream) { }
+
+        public string Alias { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -30,7 +35,5 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             stream.WriteUTF8String(Alias);
         }
-
-        public string Alias { get; set; }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/QuickTime/TrackCleanApertureDimensionsBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/QuickTime/TrackCleanApertureDimensionsBox.cs
@@ -9,8 +9,47 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("clef", "Track Clean Aperture Dimensions Atom")]
     public sealed class TrackCleanApertureDimensionsBox : FullBox
     {
-        public TrackCleanApertureDimensionsBox() : base() { }
-        public TrackCleanApertureDimensionsBox(Stream stream) : base(stream) { }
+        public TrackCleanApertureDimensionsBox() 
+            : base() { }
+
+        public TrackCleanApertureDimensionsBox(Stream stream) 
+            : base(stream) { }
+
+        /// <summary>
+        /// 16.16 Fixed-Point Number
+        /// </summary>
+        public uint Width { get; set; }
+
+        public double WidthAsDouble
+        {
+            get
+            {
+                double decimalWidth = (double)Width;
+                return decimalWidth / 65536;
+            }
+            set
+            {
+                Width = (uint)Math.Round(value * 65536, 0);
+            }
+        }
+
+        /// <summary>
+        /// 16.16 Fixed-Point Number
+        /// </summary>
+        public uint Height { get; set; }
+
+        public double HeightAsDouble
+        {
+            get
+            {
+                double decimalHeight = (double)Height;
+                return decimalHeight / 65536;
+            }
+            set
+            {
+                Height = (uint)Math.Round(value * 65536, 0);
+            }
+        }
 
         internal override ulong CalculateSize()
         {
@@ -31,40 +70,6 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             stream.WriteBEUInt32(Width);
             stream.WriteBEUInt32(Height);
-        }
-
-        /// <summary>
-        /// 16.16 Fixed-Point Number
-        /// </summary>
-        public uint Width { get; set; }
-        public double WidthAsDouble
-        {
-            get
-            {
-                double decimalWidth = (double)Width;
-                return decimalWidth / 65536;
-            }
-            set
-            {
-                Width = (uint)Math.Round(value * 65536, 0);
-            }
-        }
-
-        /// <summary>
-        /// 16.16 Fixed-Point Number
-        /// </summary>
-        public uint Height { get; set; }
-        public double HeightAsDouble
-        {
-            get
-            {
-                double decimalHeight = (double)Height;
-                return decimalHeight / 65536;
-            }
-            set
-            {
-                Height = (uint)Math.Round(value * 65536, 0);
-            }
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/QuickTime/TrackEncodedPixelsDimensionsBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/QuickTime/TrackEncodedPixelsDimensionsBox.cs
@@ -9,8 +9,39 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("enof", "Track Encoded Pixels Dimensions Atom")]
     public sealed class TrackEncodedPixelsDimensionsBox : FullBox
     {
-        public TrackEncodedPixelsDimensionsBox() : base() { }
-        public TrackEncodedPixelsDimensionsBox(Stream stream) : base(stream) { }
+        public TrackEncodedPixelsDimensionsBox()
+            : base() { }
+
+        public TrackEncodedPixelsDimensionsBox(Stream stream) 
+            : base(stream) { }
+
+        /// <summary>
+        /// 16.16 Fixed-Point Number
+        /// </summary>
+        public uint Width { get; set; }
+        public double WidthAsDouble
+        {
+            get
+            {
+                double decimalWidth = (double)Width;
+                return decimalWidth / 65536;
+            }
+            set => Width = (uint)Math.Round(value * 65536, 0);
+        }
+
+        /// <summary>
+        /// 16.16 Fixed-Point Number
+        /// </summary>
+        public uint Height { get; set; }
+        public double HeightAsDouble
+        {
+            get
+            {
+                double decimalHeight = (double)Height;
+                return decimalHeight / 65536;
+            }
+            set => Height = (uint)Math.Round(value * 65536, 0);
+        }
 
         internal override ulong CalculateSize()
         {
@@ -33,38 +64,5 @@ namespace MatrixIO.IO.Bmff.Boxes
             stream.WriteBEUInt32(Height);
         }
 
-        /// <summary>
-        /// 16.16 Fixed-Point Number
-        /// </summary>
-        public uint Width { get; set; }
-        public double WidthAsDouble
-        {
-            get
-            {
-                double decimalWidth = (double)Width;
-                return decimalWidth / 65536;
-            }
-            set
-            {
-                Width = (uint)Math.Round(value * 65536, 0);
-            }
-        }
-
-        /// <summary>
-        /// 16.16 Fixed-Point Number
-        /// </summary>
-        public uint Height { get; set; }
-        public double HeightAsDouble
-        {
-            get
-            {
-                double decimalHeight = (double)Height;
-                return decimalHeight / 65536;
-            }
-            set
-            {
-                Height = (uint)Math.Round(value * 65536, 0);
-            }
-        }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/QuickTime/TrackProductionApertureDimensionsBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/QuickTime/TrackProductionApertureDimensionsBox.cs
@@ -9,8 +9,41 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("prof", "Track Production Aperture Dimensions Atom")]
     public sealed class TrackProductionApertureDimensionsBox : FullBox
     {
-        public TrackProductionApertureDimensionsBox() : base() { }
-        public TrackProductionApertureDimensionsBox(Stream stream) : base(stream) { }
+        public TrackProductionApertureDimensionsBox() 
+            : base() { }
+
+        public TrackProductionApertureDimensionsBox(Stream stream)
+            : base(stream) { }
+
+        /// <summary>
+        /// 16.16 Fixed-Point Number
+        /// </summary>
+        public uint Width { get; set; }
+
+        public double WidthAsDouble
+        {
+            get
+            {
+                double decimalWidth = (double)Width;
+                return decimalWidth / 65536;
+            }
+            set => Width = (uint)Math.Round(value * 65536, 0);
+        }
+
+        /// <summary>
+        /// 16.16 Fixed-Point Number
+        /// </summary>
+        public uint Height { get; set; }
+
+        public double HeightAsDouble
+        {
+            get
+            {
+                double decimalHeight = (double)Height;
+                return decimalHeight / 65536;
+            }
+            set => Height = (uint)Math.Round(value * 65536, 0);
+        }
 
         internal override ulong CalculateSize()
         {
@@ -31,40 +64,6 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             stream.WriteBEUInt32(Width);
             stream.WriteBEUInt32(Height);
-        }
-
-        /// <summary>
-        /// 16.16 Fixed-Point Number
-        /// </summary>
-        public uint Width { get; set; }
-        public double WidthAsDouble
-        {
-            get
-            {
-                double decimalWidth = (double)Width;
-                return decimalWidth / 65536;
-            }
-            set
-            {
-                Width = (uint)Math.Round(value * 65536, 0);
-            }
-        }
-
-        /// <summary>
-        /// 16.16 Fixed-Point Number
-        /// </summary>
-        public uint Height { get; set; }
-        public double HeightAsDouble
-        {
-            get
-            {
-                double decimalHeight = (double)Height;
-                return decimalHeight / 65536;
-            }
-            set
-            {
-                Height = (uint)Math.Round(value * 65536, 0);
-            }
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleDependencyTypeBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleDependencyTypeBox.cs
@@ -9,8 +9,13 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("sdtp", "Simple Dependency Type Box")]
     public sealed class SampleDependencyTypeBox : FullBox, ITableBox<SampleDependencyTypeBox.SampleDependencyEntry>
     {
-        public SampleDependencyTypeBox() : base() { }
-        public SampleDependencyTypeBox(Stream stream) : base(stream) { }
+        public SampleDependencyTypeBox() 
+            : base() { }
+
+        public SampleDependencyTypeBox(Stream stream) 
+            : base(stream) { }
+
+        public IList<SampleDependencyEntry> Entries { get; } = new List<SampleDependencyEntry>();
 
         internal override ulong CalculateSize()
         {
@@ -38,8 +43,6 @@ namespace MatrixIO.IO.Bmff.Boxes
             }
         }
 
-        public IList<SampleDependencyEntry> Entries { get; } = new List<SampleDependencyEntry>();
-
         public readonly struct SampleDependencyEntry
         {
             public SampleDependencyEntry(byte sampleDependency)
@@ -53,6 +56,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             {
                 return entry.SampleDependency;
             }
+
             public static implicit operator SampleDependencyEntry(byte sampleDependency)
             {
                 return new SampleDependencyEntry(sampleDependency);

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleDescriptionBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleDescriptionBox.cs
@@ -31,7 +31,7 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             stream.WriteBEUInt32((uint)Children.Count);
         }
-        
+
         private uint _EntryCount;
 
         public IList<Box> Children { get; } = new List<Box>();

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleSizeBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleSizeBox.cs
@@ -11,8 +11,19 @@ namespace MatrixIO.IO.Bmff.Boxes
     {
         private uint _sampleCount;
 
-        public SampleSizeBox() : base() { }
-        public SampleSizeBox(Stream stream) : base(stream) { }
+        public SampleSizeBox() 
+            : base() { }
+
+        public SampleSizeBox(Stream stream) 
+            : base(stream) { }
+
+        public uint SampleSize { get; set; }
+
+        public uint SampleCount => (SampleSize == 0) ? (uint)Entries.Count : _sampleCount;
+
+        public IList<SampleSizeEntry> Entries { get; } = new List<SampleSizeEntry>();
+
+        public uint EntryCount => (uint)Entries.Count;
 
         internal override ulong CalculateSize()
         {
@@ -47,14 +58,6 @@ namespace MatrixIO.IO.Bmff.Boxes
                 stream.WriteBEUInt32(SampleSizeEntry.EntrySize);
             }
         }
-
-        public IList<SampleSizeEntry> Entries { get; } = new List<SampleSizeEntry>();
-
-        public uint SampleSize { get; set; }
-
-        public uint SampleCount => (SampleSize == 0) ? (uint)Entries.Count : _sampleCount;
-
-        public uint EntryCount => (uint)Entries.Count;
 
         public readonly struct SampleSizeEntry
         {

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleSizeBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleSizeBox.cs
@@ -9,6 +9,8 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("stsz", "Sample Size Box")]
     public sealed class SampleSizeBox : FullBox, ITableBox<SampleSizeBox.SampleSizeEntry>
     {
+        private uint _sampleCount;
+
         public SampleSizeBox() : base() { }
         public SampleSizeBox(Stream stream) : base(stream) { }
 
@@ -48,20 +50,12 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public IList<SampleSizeEntry> Entries { get; } = new List<SampleSizeEntry>();
 
-
         public uint SampleSize { get; set; }
-        private uint _sampleCount;
-        public uint SampleCount
-        {
-            get
-            {
-                if (SampleSize == 0) return (uint)Entries.Count;
-                return _sampleCount;
-            }
-        }
+
+        public uint SampleCount => (SampleSize == 0) ? (uint)Entries.Count : _sampleCount;
 
         public uint EntryCount => (uint)Entries.Count;
-           
+
         public readonly struct SampleSizeEntry
         {
             public SampleSizeEntry(uint entrySize)

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleToChunkBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleToChunkBox.cs
@@ -7,7 +7,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Sample To Chunk Box ("stsc")
     /// </summary>
     [Box("stsc", "Sample To Chunk Box")]
-    public class SampleToChunkBox : FullBox, ITableBox<SampleToChunkBox.SampleToChunkEntry>
+    public sealed class SampleToChunkBox : FullBox, ITableBox<SampleToChunkBox.SampleToChunkEntry>
     {
         public SampleToChunkBox() : base() { }
         public SampleToChunkBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleToChunkBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleToChunkBox.cs
@@ -25,12 +25,11 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             for (uint i = 0; i < entryCount; i++)
             {
-                Entries.Add(new SampleToChunkEntry()
-                {
-                    FirstChunk = stream.ReadBEUInt32(),
-                    SamplesPerChunk = stream.ReadBEUInt32(),
-                    SampleDescriptionIndex = stream.ReadBEUInt32(),
-                });
+                Entries.Add(new SampleToChunkEntry(
+                    firstChunk: stream.ReadBEUInt32(),
+                    samplesPerChunk: stream.ReadBEUInt32(),
+                    sampleDescriptionIndex: stream.ReadBEUInt32()
+                ));
             }
         }
 
@@ -52,19 +51,20 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public int EntryCount => Entries.Count;
 
-        public class SampleToChunkEntry
+        public readonly struct SampleToChunkEntry
         {
-            public uint FirstChunk { get; set; }
-            public uint SamplesPerChunk { get; set; }
-            public uint SampleDescriptionIndex { get; set; }
-
-            public SampleToChunkEntry() { }
             public SampleToChunkEntry(uint firstChunk, uint samplesPerChunk, uint sampleDescriptionIndex)
             {
                 FirstChunk = firstChunk;
                 SamplesPerChunk = samplesPerChunk;
                 SampleDescriptionIndex = sampleDescriptionIndex;
             }
+
+            public uint FirstChunk { get; }
+
+            public uint SamplesPerChunk { get; }
+
+            public uint SampleDescriptionIndex { get; }
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleToChunkBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleToChunkBox.cs
@@ -9,8 +9,15 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("stsc", "Sample To Chunk Box")]
     public sealed class SampleToChunkBox : FullBox, ITableBox<SampleToChunkBox.SampleToChunkEntry>
     {
-        public SampleToChunkBox() : base() { }
-        public SampleToChunkBox(Stream stream) : base(stream) { }
+        public SampleToChunkBox() 
+            : base() { }
+
+        public SampleToChunkBox(Stream stream) 
+            : base(stream) { }
+
+        public IList<SampleToChunkEntry> Entries { get; } = new List<SampleToChunkEntry>();
+
+        public int EntryCount => Entries.Count;
 
         internal override ulong CalculateSize()
         {
@@ -46,10 +53,6 @@ namespace MatrixIO.IO.Bmff.Boxes
                 stream.WriteBEUInt32(SampleToChunkEntry.SampleDescriptionIndex);
             }
         }
-
-        public IList<SampleToChunkEntry> Entries { get; } = new List<SampleToChunkEntry>();
-
-        public int EntryCount => Entries.Count;
 
         public readonly struct SampleToChunkEntry
         {

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SkipBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SkipBox.cs
@@ -7,7 +7,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Alternative to the Free Space box.
     /// </summary>
     [Box("skip", "Skip Box")]
-    public class SkipBox : Box, IContentBox
+    public sealed class SkipBox : Box, IContentBox
     {
         public SkipBox() : base() { }
         public SkipBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SoundMediaHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SoundMediaHeaderBox.cs
@@ -10,8 +10,13 @@ namespace MatrixIO.IO.Bmff.Boxes
     {
         private ushort _reserved;
 
-        public SoundMediaHeaderBox() : base() { }
-        public SoundMediaHeaderBox(Stream stream) : base(stream) { }
+        public SoundMediaHeaderBox() 
+            : base() { }
+
+        public SoundMediaHeaderBox(Stream stream) 
+            : base(stream) { }
+
+        public short Balance { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -33,7 +38,5 @@ namespace MatrixIO.IO.Bmff.Boxes
             stream.WriteBEInt16(Balance);
             stream.WriteBEUInt16(_reserved);
         }
-
-        public short Balance { get; set; }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SoundMediaHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SoundMediaHeaderBox.cs
@@ -8,6 +8,8 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("smhd", "Sound Media Header Box")]
     public sealed class SoundMediaHeaderBox : FullBox
     {
+        private ushort _reserved;
+
         public SoundMediaHeaderBox() : base() { }
         public SoundMediaHeaderBox(Stream stream) : base(stream) { }
 
@@ -21,7 +23,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             base.LoadFromStream(stream);
 
             Balance = stream.ReadBEInt16();
-            _Reserved = stream.ReadBEUInt16();
+            _reserved = stream.ReadBEUInt16();
         }
 
         protected override void SaveToStream(Stream stream)
@@ -29,10 +31,9 @@ namespace MatrixIO.IO.Bmff.Boxes
             base.SaveToStream(stream);
 
             stream.WriteBEInt16(Balance);
-            stream.WriteBEUInt16(_Reserved);
+            stream.WriteBEUInt16(_reserved);
         }
 
         public short Balance { get; set; }
-        private ushort _Reserved;
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SoundMediaHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SoundMediaHeaderBox.cs
@@ -8,15 +8,15 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("smhd", "Sound Media Header Box")]
     public sealed class SoundMediaHeaderBox : FullBox
     {
-        private ushort _reserved;
-
-        public SoundMediaHeaderBox() 
+        public SoundMediaHeaderBox()
             : base() { }
 
-        public SoundMediaHeaderBox(Stream stream) 
+        public SoundMediaHeaderBox(Stream stream)
             : base(stream) { }
 
         public short Balance { get; set; }
+
+        private ushort Reserved { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -28,7 +28,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             base.LoadFromStream(stream);
 
             Balance = stream.ReadBEInt16();
-            _reserved = stream.ReadBEUInt16();
+            Reserved = stream.ReadBEUInt16();
         }
 
         protected override void SaveToStream(Stream stream)
@@ -36,7 +36,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             base.SaveToStream(stream);
 
             stream.WriteBEInt16(Balance);
-            stream.WriteBEUInt16(_reserved);
+            stream.WriteBEUInt16(Reserved);
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SoundMediaHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SoundMediaHeaderBox.cs
@@ -6,7 +6,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Sound Media Header Box ("smhd")
     /// </summary>
     [Box("smhd", "Sound Media Header Box")]
-    public class SoundMediaHeaderBox : FullBox
+    public sealed class SoundMediaHeaderBox : FullBox
     {
         public SoundMediaHeaderBox() : base() { }
         public SoundMediaHeaderBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SyncSampleBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SyncSampleBox.cs
@@ -9,8 +9,15 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("stss", "Sync Sample Box")]
     public sealed class SyncSampleBox : FullBox, ITableBox<SyncSampleBox.SyncSampleEntry>
     {
-        public SyncSampleBox() : base() { }
-        public SyncSampleBox(Stream stream) : base(stream) { }
+        public SyncSampleBox() 
+            : base() { }
+
+        public SyncSampleBox(Stream stream) 
+            : base(stream) { }
+
+        public IList<SyncSampleEntry> Entries { get; } = new List<SyncSampleEntry>();
+
+        public int EntryCount => Entries.Count;
 
         internal override ulong CalculateSize()
         {
@@ -40,10 +47,6 @@ namespace MatrixIO.IO.Bmff.Boxes
                 stream.WriteBEUInt32(SyncSampleEntry.SampleNumber);
             }
         }
-
-        public IList<SyncSampleEntry> Entries { get; } = new List<SyncSampleEntry>();
-
-        public int EntryCount => Entries.Count;
 
         public readonly struct SyncSampleEntry
         {

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SyncSampleBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SyncSampleBox.cs
@@ -7,7 +7,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Sync Sample Box ("stss")
     /// </summary>
     [Box("stss", "Sync Sample Box")]
-    public class SyncSampleBox : FullBox, ITableBox<SyncSampleBox.SyncSampleEntry>
+    public sealed class SyncSampleBox : FullBox, ITableBox<SyncSampleBox.SyncSampleEntry>
     {
         public SyncSampleBox() : base() { }
         public SyncSampleBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TimeToSampleBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TimeToSampleBox.cs
@@ -7,7 +7,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Time To Sample Box ("stts")
     /// </summary>
     [Box("stts", "Time To Sample Box")]
-    public class TimeToSampleBox : FullBox, ITableBox<TimeToSampleBox.TimeToSampleEntry>
+    public sealed class TimeToSampleBox : FullBox, ITableBox<TimeToSampleBox.TimeToSampleEntry>
     {
         public TimeToSampleBox() : base() { }
         public TimeToSampleBox(Stream stream) : base(stream) { }
@@ -23,13 +23,17 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             uint entryCount = stream.ReadBEUInt32();
 
+            var entries = new TimeToSampleEntry[entryCount];
+
             for (uint i = 0; i < entryCount; i++)
             {
-                Entries.Add(new TimeToSampleEntry() {
-                    SampleCount = stream.ReadBEUInt32(), 
-                    SampleDelta = stream.ReadBEUInt32(),
-                });
+                entries[i] = new TimeToSampleEntry(
+                    sampleCount: stream.ReadBEUInt32(),
+                    sampleDelta: stream.ReadBEUInt32()
+                );
             }
+
+            Entries = entries;
         }
 
         protected override void SaveToStream(Stream stream)
@@ -45,21 +49,21 @@ namespace MatrixIO.IO.Bmff.Boxes
             }
         }
 
-        public IList<TimeToSampleEntry> Entries { get; } = new List<TimeToSampleEntry>();
+        public IList<TimeToSampleEntry> Entries { get; private set; }
 
-        public int EntryCount { get { return Entries.Count; } }
+        public int EntryCount => Entries.Count;
 
-        public class TimeToSampleEntry
+        public readonly struct TimeToSampleEntry
         {
-            public uint SampleCount { get; set; }
-            public uint SampleDelta { get; set; }
-
-            public TimeToSampleEntry() { }
             public TimeToSampleEntry(uint sampleCount, uint sampleDelta)
             {
                 SampleCount = sampleCount;
                 SampleDelta = sampleDelta;
             }
+
+            public uint SampleCount { get; }
+
+            public uint SampleDelta { get; }
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TimeToSampleBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TimeToSampleBox.cs
@@ -9,8 +9,15 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("stts", "Time To Sample Box")]
     public sealed class TimeToSampleBox : FullBox, ITableBox<TimeToSampleBox.TimeToSampleEntry>
     {
-        public TimeToSampleBox() : base() { }
-        public TimeToSampleBox(Stream stream) : base(stream) { }
+        public TimeToSampleBox()
+            : base() { }
+
+        public TimeToSampleBox(Stream stream) 
+            : base(stream) { }
+
+        public IList<TimeToSampleEntry> Entries { get; } = new List<TimeToSampleEntry>();
+
+        public int EntryCount => Entries.Count;
 
         internal override ulong CalculateSize()
         {
@@ -23,17 +30,14 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             uint entryCount = stream.ReadBEUInt32();
 
-            var entries = new TimeToSampleEntry[entryCount];
-
             for (uint i = 0; i < entryCount; i++)
             {
-                entries[i] = new TimeToSampleEntry(
+                Entries.Add(new TimeToSampleEntry(
                     sampleCount: stream.ReadBEUInt32(),
                     sampleDelta: stream.ReadBEUInt32()
-                );
+                ));
             }
 
-            Entries = entries;
         }
 
         protected override void SaveToStream(Stream stream)
@@ -48,10 +52,6 @@ namespace MatrixIO.IO.Bmff.Boxes
                 stream.WriteBEUInt32(TimeToSampleEntry.SampleDelta);
             }
         }
-
-        public IList<TimeToSampleEntry> Entries { get; private set; }
-
-        public int EntryCount => Entries.Count;
 
         public readonly struct TimeToSampleEntry
         {

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackBox.cs
@@ -8,7 +8,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Track Box ("trak")
     /// </summary>
     [Box("trak", "Track Box")]
-    public class TrackBox : Box, ISuperBox
+    public sealed class TrackBox : Box, ISuperBox
     {
         public TrackBox() : base() { }
         public TrackBox(Stream stream) : base(stream) { }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackExtendsBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackExtendsBox.cs
@@ -11,35 +11,10 @@ namespace MatrixIO.IO.Bmff.Boxes
     {
         private SampleFlags _defaultSampleFlags = new SampleFlags();
 
-        public TrackExtendsBox() : base() { }
-        public TrackExtendsBox(Stream stream) : base(stream) { }
-
-        internal override ulong CalculateSize()
-        {
-            return base.CalculateSize() + (5 * 4);
-        }
-
-        protected override void LoadFromStream(Stream stream)
-        {
-            base.LoadFromStream(stream);
-
-            TrackID = stream.ReadBEUInt32();
-            DefaultSampleDescriptionIndex = stream.ReadBEUInt32();
-            DefaultSampleDuration = stream.ReadBEUInt32();
-            DefaultSampleSize = stream.ReadBEUInt32();
-            _defaultSampleFlags._flags = stream.ReadBEUInt32();
-        }
-
-        protected override void SaveToStream(Stream stream)
-        {
-            base.SaveToStream(stream);
-
-            stream.WriteBEUInt32(TrackID);
-            stream.WriteBEUInt32(DefaultSampleDescriptionIndex);
-            stream.WriteBEUInt32(DefaultSampleDuration);
-            stream.WriteBEUInt32(DefaultSampleSize);
-            stream.WriteBEUInt32(_defaultSampleFlags._flags);
-        }
+        public TrackExtendsBox()
+            : base() { }
+        public TrackExtendsBox(Stream stream) 
+            : base(stream) { }
 
         public uint TrackID { get; set; }
 
@@ -83,6 +58,33 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             get => _defaultSampleFlags.DegredationPriority;
             set => _defaultSampleFlags.DegredationPriority = value;
+        }
+
+        internal override ulong CalculateSize()
+        {
+            return base.CalculateSize() + (5 * 4);
+        }
+
+        protected override void LoadFromStream(Stream stream)
+        {
+            base.LoadFromStream(stream);
+
+            TrackID = stream.ReadBEUInt32();
+            DefaultSampleDescriptionIndex = stream.ReadBEUInt32();
+            DefaultSampleDuration = stream.ReadBEUInt32();
+            DefaultSampleSize = stream.ReadBEUInt32();
+            _defaultSampleFlags._flags = stream.ReadBEUInt32();
+        }
+
+        protected override void SaveToStream(Stream stream)
+        {
+            base.SaveToStream(stream);
+
+            stream.WriteBEUInt32(TrackID);
+            stream.WriteBEUInt32(DefaultSampleDescriptionIndex);
+            stream.WriteBEUInt32(DefaultSampleDuration);
+            stream.WriteBEUInt32(DefaultSampleSize);
+            stream.WriteBEUInt32(_defaultSampleFlags._flags);
         }
     }
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackExtendsBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackExtendsBox.cs
@@ -9,6 +9,8 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("trex", "Track Extends Box")]
     public sealed class TrackExtendsBox : FullBox
     {
+        private SampleFlags _defaultSampleFlags = new SampleFlags();
+
         public TrackExtendsBox() : base() { }
         public TrackExtendsBox(Stream stream) : base(stream) { }
 
@@ -25,7 +27,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             DefaultSampleDescriptionIndex = stream.ReadBEUInt32();
             DefaultSampleDuration = stream.ReadBEUInt32();
             DefaultSampleSize = stream.ReadBEUInt32();
-            DefaultSampleFlags._flags = stream.ReadBEUInt32();
+            _defaultSampleFlags._flags = stream.ReadBEUInt32();
         }
 
         protected override void SaveToStream(Stream stream)
@@ -36,64 +38,51 @@ namespace MatrixIO.IO.Bmff.Boxes
             stream.WriteBEUInt32(DefaultSampleDescriptionIndex);
             stream.WriteBEUInt32(DefaultSampleDuration);
             stream.WriteBEUInt32(DefaultSampleSize);
-            stream.WriteBEUInt32(DefaultSampleFlags._flags);
+            stream.WriteBEUInt32(_defaultSampleFlags._flags);
         }
 
         public uint TrackID { get; set; }
+
         public uint DefaultSampleDescriptionIndex { get; set; }
+
         public uint DefaultSampleDuration { get; set; }
+
         public uint DefaultSampleSize { get; set; }
-        private SampleFlags DefaultSampleFlags = new SampleFlags();
 
         public byte DefaultSampleDependsOn
         {
-            get => DefaultSampleFlags.SampleDependsOn;
-            set
-            {
-                DefaultSampleFlags.SampleDependsOn = value;
-            }
+            get => _defaultSampleFlags.SampleDependsOn;
+            set => _defaultSampleFlags.SampleDependsOn = value;
         }
 
         public byte DefaultSampleIsDependedOn
         {
-            get => DefaultSampleFlags.SampleIsDependedOn;
-            set
-            {
-                DefaultSampleFlags.SampleIsDependedOn = value;
-            }
+            get => _defaultSampleFlags.SampleIsDependedOn;
+            set => _defaultSampleFlags.SampleIsDependedOn = value;
         }
 
         public byte DefaultSampleHasRedundancy
         {
-            get => DefaultSampleFlags.SampleHasRedundancy;
-            set
-            {
-                DefaultSampleFlags.SampleHasRedundancy = value;
-            }
+            get => _defaultSampleFlags.SampleHasRedundancy;
+            set => _defaultSampleFlags.SampleHasRedundancy = value;
         }
 
         public byte DefaultSamplePaddingValue
         {
-            get => DefaultSampleFlags.SamplePaddingValue;
-            set => DefaultSampleFlags.SamplePaddingValue = value;
+            get => _defaultSampleFlags.SamplePaddingValue;
+            set => _defaultSampleFlags.SamplePaddingValue = value;
         }
 
         public bool DefaultSampleIsDifferenceValue
         {
-            get => DefaultSampleFlags.SampleIsDifferenceValue;
-            set
-            {
-                DefaultSampleFlags.SampleIsDifferenceValue = value;
-            }
+            get => _defaultSampleFlags.SampleIsDifferenceValue;
+            set => _defaultSampleFlags.SampleIsDifferenceValue = value;
         }
 
         public ushort DefaultDegredationPriority
         {
-            get => DefaultSampleFlags.DegredationPriority;
-            set
-            {
-                DefaultSampleFlags.DegredationPriority = value;
-            }
+            get => _defaultSampleFlags.DegredationPriority;
+            set => _defaultSampleFlags.DegredationPriority = value;
         }
     }
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackExtendsBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackExtendsBox.cs
@@ -47,10 +47,7 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public byte DefaultSampleDependsOn
         {
-            get
-            {
-                return DefaultSampleFlags.SampleDependsOn;
-            }
+            get => DefaultSampleFlags.SampleDependsOn;
             set
             {
                 DefaultSampleFlags.SampleDependsOn = value;
@@ -59,10 +56,7 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public byte DefaultSampleIsDependedOn
         {
-            get
-            {
-                return DefaultSampleFlags.SampleIsDependedOn;
-            }
+            get => DefaultSampleFlags.SampleIsDependedOn;
             set
             {
                 DefaultSampleFlags.SampleIsDependedOn = value;
@@ -71,10 +65,7 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public byte DefaultSampleHasRedundancy
         {
-            get
-            {
-                return DefaultSampleFlags.SampleHasRedundancy;
-            }
+            get => DefaultSampleFlags.SampleHasRedundancy;
             set
             {
                 DefaultSampleFlags.SampleHasRedundancy = value;
@@ -83,22 +74,13 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public byte DefaultSamplePaddingValue
         {
-            get
-            {
-                return DefaultSampleFlags.SamplePaddingValue;
-            }
-            set
-            {
-                DefaultSampleFlags.SamplePaddingValue = value;
-            }
+            get => DefaultSampleFlags.SamplePaddingValue;
+            set => DefaultSampleFlags.SamplePaddingValue = value;
         }
 
         public bool DefaultSampleIsDifferenceValue
         {
-            get
-            {
-                return DefaultSampleFlags.SampleIsDifferenceValue;
-            }
+            get => DefaultSampleFlags.SampleIsDifferenceValue;
             set
             {
                 DefaultSampleFlags.SampleIsDifferenceValue = value;
@@ -107,10 +89,7 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public ushort DefaultDegredationPriority
         {
-            get
-            {
-                return DefaultSampleFlags.DegredationPriority;
-            }
+            get => DefaultSampleFlags.DegredationPriority;
             set
             {
                 DefaultSampleFlags.DegredationPriority = value;
@@ -130,10 +109,7 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public byte SampleDependsOn // 2 bits -- Defined in Independent and Disposable Samples Box
         {
-            get
-            {
-                return (byte)((_flags & 0x3000000) >> 24);
-            }
+            get => (byte)((_flags & 0x3000000) >> 24);
             set
             {
                 if (value > 3) throw new ArgumentOutOfRangeException("SampleDependsOn is a 2 bit field and only accepts values 0 through 4.");
@@ -143,10 +119,7 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public byte SampleIsDependedOn // 2 bits -- Defined in Independent and Disposable Samples Box
         {
-            get
-            {
-                return (byte)((_flags & 0x00C00000) >> 22);
-            }
+            get => (byte)((_flags & 0x00C00000) >> 22);
             set
             {
                 if (value > 3) throw new ArgumentOutOfRangeException("SampleIsDependedOn is a 2 bit field and only accepts values 0 through 4.");
@@ -156,10 +129,7 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public byte SampleHasRedundancy // 2 bits -- Defined in Independent and Disposable Samples Box
         {
-            get
-            {
-                return (byte)((_flags & 0x00300000) >> 20);
-            }
+            get => (byte)((_flags & 0x00300000) >> 20);
             set
             {
                 if (value > 3) throw new ArgumentOutOfRangeException("SampleHasRedundancy is a 2 bit field and only accepts values 0 through 4.");
@@ -169,10 +139,7 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public byte SamplePaddingValue // 3 bits -- Defined in degredation priority table
         {
-            get
-            {
-                return (byte)((_flags & 0x000E0000) >> 17);
-            }
+            get => (byte)((_flags & 0x000E0000) >> 17);
             set
             {
                 if (value > 7) throw new ArgumentOutOfRangeException("SamplePaddingValue is a 3 bit field and only accepts values 0 through 7.");
@@ -182,26 +149,14 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public bool SampleIsDifferenceValue // 1 bit
         {
-            get
-            {
-                return (_flags & 0x00010000) == 0x00010000;
-            }
-            set
-            {
-                _flags |= 0x00010000;
-            }
+            get => (_flags & 0x00010000) == 0x00010000;
+            set => _flags |= 0x00010000;
         }
 
         public ushort DegredationPriority // 16 bits
         {
-            get
-            {
-                return (ushort)(_flags & 0x0000FFFF);
-            }
-            set
-            {
-                _flags = (_flags & 0xFFFF0000) | value;
-            }
+            get => (ushort)(_flags & 0x0000FFFF);
+            set => _flags = (_flags & 0xFFFF0000) | value;
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackFragmentBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackFragmentBox.cs
@@ -8,11 +8,11 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Track Fragment Box ("traf")
     /// </summary>
     [Box("traf", "Track Fragment Box")]
-    public class TrackFragmentBox : Box, ISuperBox
+    public sealed class TrackFragmentBox : Box, ISuperBox
     {
         public TrackFragmentBox() : base() { }
         public TrackFragmentBox(Stream stream) : base(stream) { }
-        
+
         public IList<Box> Children { get; } = new List<Box>();
 
         public IEnumerator<Box> GetEnumerator() => Children.GetEnumerator();

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackFragmentHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackFragmentHeaderBox.cs
@@ -9,18 +9,41 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("tfhd", "Track Fragment Header Box")]
     public sealed class TrackFragmentHeaderBox : FullBox
     {
-        public TrackFragmentHeaderBox() : base() { }
-        public TrackFragmentHeaderBox(Stream stream) : base(stream) { }
+        public TrackFragmentHeaderBox()
+            : base() { }
+
+        public TrackFragmentHeaderBox(Stream stream)
+            : base(stream) { }
+
+        public uint TrackID { get; set; }
+
+        public ulong? BaseDataOffset { get; set; }
+
+        public uint? SampleDescriptionIndex { get; set; }
+
+        public uint? DefaultSampleDuration { get; set; }
+
+        public uint? DefaultSampleSize { get; set; }
+
+        public SampleFlags DefaultSampleFlags { get; set; }
+
+        bool DurationIsEmpty { get; set; }
+
+        private new TrackFragmentFlags Flags
+        {
+            get => (TrackFragmentFlags)_flags;
+            set => _flags = (uint)value;
+        }
 
         internal override ulong CalculateSize()
         {
             ulong calculatedSize = base.CalculateSize() + 4;
 
-            if (BaseDataOffset.HasValue) calculatedSize += 8;
+            if (BaseDataOffset.HasValue)         calculatedSize += 8;
             if (SampleDescriptionIndex.HasValue) calculatedSize += 4;
-            if (DefaultSampleDuration.HasValue) calculatedSize += 4;
-            if (DefaultSampleSize.HasValue) calculatedSize += 4;
-            if (DefaultSampleFlags != null) calculatedSize += 4;
+            if (DefaultSampleDuration.HasValue)  calculatedSize += 4;
+            if (DefaultSampleSize.HasValue)      calculatedSize += 4;
+            if (DefaultSampleFlags != null)      calculatedSize += 4;
 
             return calculatedSize;
         }
@@ -32,56 +55,59 @@ namespace MatrixIO.IO.Bmff.Boxes
             TrackID = stream.ReadBEUInt32();
 
             if ((Flags & TrackFragmentFlags.BaseDataOffsetPresent) == TrackFragmentFlags.BaseDataOffsetPresent)
+            {
                 BaseDataOffset = stream.ReadBEUInt64();
+            }
+
             if ((Flags & TrackFragmentFlags.SampleDrescriptionIndexPresent) == TrackFragmentFlags.SampleDrescriptionIndexPresent)
+            {
                 SampleDescriptionIndex = stream.ReadBEUInt32();
+            }
+
             if ((Flags & TrackFragmentFlags.DefaultSampleDurationPresent) == TrackFragmentFlags.DefaultSampleDurationPresent)
+            {
                 DefaultSampleDuration = stream.ReadBEUInt32();
+            }
+
             if ((Flags & TrackFragmentFlags.DefaultSampleSizePresent) == TrackFragmentFlags.DefaultSampleSizePresent)
+            {
                 DefaultSampleSize = stream.ReadBEUInt32();
+            }
+
             if ((Flags & TrackFragmentFlags.DefaultSampleFlagsPresent) == TrackFragmentFlags.DefaultSampleFlagsPresent)
+            {
                 DefaultSampleFlags = new SampleFlags(stream.ReadBEUInt32());
+            }
 
             if ((Flags & TrackFragmentFlags.DurationIsEmpty) == TrackFragmentFlags.DurationIsEmpty)
+            {
                 DurationIsEmpty = true;
+            }
         }
 
         protected override void SaveToStream(Stream stream)
         {
-            TrackFragmentFlags newFlags = 0;
-            if (BaseDataOffset.HasValue) newFlags |= TrackFragmentFlags.BaseDataOffsetPresent;
+            TrackFragmentFlags newFlags = default;
+
+            if (BaseDataOffset.HasValue)         newFlags |= TrackFragmentFlags.BaseDataOffsetPresent;
             if (SampleDescriptionIndex.HasValue) newFlags |= TrackFragmentFlags.SampleDrescriptionIndexPresent;
-            if (DefaultSampleDuration.HasValue) newFlags |= TrackFragmentFlags.DefaultSampleDurationPresent;
-            if (DefaultSampleSize.HasValue) newFlags |= TrackFragmentFlags.DefaultSampleSizePresent;
-            if (DefaultSampleFlags != null) newFlags |= TrackFragmentFlags.DefaultSampleFlagsPresent;
-            if (DurationIsEmpty) newFlags |= TrackFragmentFlags.DurationIsEmpty;
+            if (DefaultSampleDuration.HasValue)  newFlags |= TrackFragmentFlags.DefaultSampleDurationPresent;
+            if (DefaultSampleSize.HasValue)      newFlags |= TrackFragmentFlags.DefaultSampleSizePresent;
+            if (DefaultSampleFlags != null)      newFlags |= TrackFragmentFlags.DefaultSampleFlagsPresent;
+            if (DurationIsEmpty)                 newFlags |= TrackFragmentFlags.DurationIsEmpty;
 
             Flags = newFlags;
 
             base.SaveToStream(stream);
 
             stream.WriteBEUInt32(TrackID);
-            if (BaseDataOffset.HasValue) stream.WriteBEUInt64(BaseDataOffset.Value);
+
+            if (BaseDataOffset.HasValue)         stream.WriteBEUInt64(BaseDataOffset.Value);
             if (SampleDescriptionIndex.HasValue) stream.WriteBEUInt32(SampleDescriptionIndex.Value);
-            if (DefaultSampleDuration.HasValue) stream.WriteBEUInt32(DefaultSampleDuration.Value);
-            if (DefaultSampleSize.HasValue) stream.WriteBEUInt32(DefaultSampleSize.Value);
-            if (DefaultSampleFlags != null) stream.WriteBEUInt32(DefaultSampleFlags._flags);
+            if (DefaultSampleDuration.HasValue)  stream.WriteBEUInt32(DefaultSampleDuration.Value);
+            if (DefaultSampleSize.HasValue)      stream.WriteBEUInt32(DefaultSampleSize.Value);
+            if (DefaultSampleFlags != null)      stream.WriteBEUInt32(DefaultSampleFlags._flags);
         }
-
-
-        private new TrackFragmentFlags Flags
-        {
-            get => (TrackFragmentFlags)_Flags;
-            set => _Flags = (uint)value;
-        }
-
-        public uint TrackID { get; set; }
-        public ulong? BaseDataOffset { get; set; }
-        public uint? SampleDescriptionIndex { get; set; }
-        public uint? DefaultSampleDuration { get; set; }
-        public uint? DefaultSampleSize { get; set; }
-        public SampleFlags DefaultSampleFlags { get; set; }
-        bool DurationIsEmpty { get; set; }
 
         [Flags]
         public enum TrackFragmentFlags : int

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackFragmentRandomAccessBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackFragmentRandomAccessBox.cs
@@ -11,6 +11,10 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("tfra", "Track Fragment Random Access Box")]
     public sealed class TrackFragmentRandomAccessBox : FullBox, ITableBox<TrackFragmentRandomAccessBox.TrackFragmentEntry>
     {
+        private byte[] _reserved = new byte[4];
+        private byte _sizeOf;
+        private readonly List<TrackFragmentEntry> _entries = new List<TrackFragmentEntry>();
+
         public TrackFragmentRandomAccessBox() : base() { }
         public TrackFragmentRandomAccessBox(Stream stream) : base(stream) { }
 
@@ -30,13 +34,15 @@ namespace MatrixIO.IO.Bmff.Boxes
             base.LoadFromStream(stream);
 
             TrackID = stream.ReadBEUInt32();
-            Reserved = stream.ReadBytes(3);
-            _SizeOf = stream.ReadOneByte();
+            _reserved = stream.ReadBytes(3);
+            _sizeOf = stream.ReadOneByte();
 
-            uint NumberOfEntries = stream.ReadBEUInt32();
-            for (uint i = 0; i < NumberOfEntries; i++)
+            uint entryCount = stream.ReadBEUInt32();
+
+            for (uint i = 0; i < entryCount; i++)
             {
-                TrackFragmentEntry entry = new TrackFragmentEntry();
+                var entry = new TrackFragmentEntry();
+
                 if (Version == 0x01)
                 {
                     entry.Time = stream.ReadBEUInt64();
@@ -48,56 +54,70 @@ namespace MatrixIO.IO.Bmff.Boxes
                     entry.MoofOffset = stream.ReadBEUInt32();
                 }
 
-                if (SizeOfTrafNumber == 1) entry.TrafNumber = stream.ReadOneByte();
-                else if (SizeOfTrafNumber == 2) entry.TrafNumber = stream.ReadBEUInt16();
-                else if (SizeOfTrafNumber == 3) entry.TrafNumber = stream.ReadBEUInt24();
-                else entry.TrafNumber = stream.ReadBEUInt32();
+                switch (SizeOfTrafNumber)
+                {
+                    case 1: entry.TrafNumber = stream.ReadOneByte(); break;
+                    case 2: entry.TrafNumber = stream.ReadBEUInt16(); break;
+                    case 3: entry.TrafNumber = stream.ReadBEUInt24(); break;
+                    default: entry.TrafNumber = stream.ReadBEUInt32(); break;
+                }
 
-                if (SizeOfTrunNumber == 1) entry.TrunNumber = stream.ReadOneByte();
-                else if (SizeOfTrunNumber == 2) entry.TrunNumber = stream.ReadBEUInt16();
-                else if (SizeOfTrunNumber == 3) entry.TrunNumber = stream.ReadBEUInt24();
-                else entry.TrunNumber = stream.ReadBEUInt32();
+                switch (SizeOfTrunNumber)
+                {
+                    case 1: entry.TrunNumber = stream.ReadOneByte(); break;
+                    case 2: entry.TrunNumber = stream.ReadBEUInt16(); break;
+                    case 3: entry.TrunNumber = stream.ReadBEUInt24(); break;
+                    default: entry.TrunNumber = stream.ReadBEUInt32(); break;
+                }
 
-                if (SizeOfSampleNumber == 1) entry.SampleNumber = stream.ReadOneByte();
-                else if (SizeOfSampleNumber == 2) entry.SampleNumber = stream.ReadBEUInt16();
-                else if (SizeOfSampleNumber == 3) entry.SampleNumber = stream.ReadBEUInt24();
-                else entry.SampleNumber = stream.ReadBEUInt32();
+                switch (SizeOfSampleNumber)
+                {
+                    case 1: entry.SampleNumber = stream.ReadOneByte(); break;
+                    case 2: entry.SampleNumber = stream.ReadBEUInt16(); break;
+                    case 3: entry.SampleNumber = stream.ReadBEUInt24(); break;
+                    default: entry.SampleNumber = stream.ReadBEUInt32(); break;
+                }
 
-                _Entries.Add(entry);
+                _entries.Add(entry);
             }
         }
 
         protected override void SaveToStream(Stream stream)
         {
-            if ((from entry in _Entries select Math.Max(entry.Time, entry.MoofOffset)).Max() > UInt32.MaxValue) Version = 1;
-            else Version = 0;
+            sbyte GetIntSize(uint value)
+            {
+                if (value > 16777215) return 4;
+                else if (value > ushort.MaxValue) return 3;
+                else if (value > byte.MaxValue) return 2;
+                else return 1;
+            }
 
-            uint MaxTrafNumber = (from entry in _Entries select entry.TrafNumber).Max();
-            if (MaxTrafNumber > 16777215) SizeOfTrafNumber = 4;
-            else if (MaxTrafNumber > UInt16.MaxValue) SizeOfTrafNumber = 3;
-            else if (MaxTrafNumber > byte.MaxValue) SizeOfTrafNumber = 2;
-            else SizeOfTrafNumber = 1;
+            bool has64BitEntry = false;
 
-            uint MaxTrunNumber = (from entry in _Entries select entry.TrunNumber).Max();
-            if (MaxTrunNumber > 16777215) SizeOfTrunNumber = 4;
-            else if (MaxTrunNumber > UInt16.MaxValue) SizeOfTrunNumber = 3;
-            else if (MaxTrunNumber > byte.MaxValue) SizeOfTrunNumber = 2;
-            else SizeOfTrunNumber = 1;
+            foreach (var entry in _entries)
+            {
+                if (entry.Time > uint.MaxValue || entry.MoofOffset > uint.MaxValue)
+                {
+                    has64BitEntry = true;
 
-            uint MaxSampleNumber = (from entry in _Entries select entry.SampleNumber).Max();
-            if (MaxSampleNumber > 16777215) SizeOfSampleNumber = 4;
-            else if (MaxSampleNumber > UInt16.MaxValue) SizeOfSampleNumber = 3;
-            else if (MaxSampleNumber > byte.MaxValue) SizeOfSampleNumber = 2;
-            else SizeOfSampleNumber = 1;
+                    break;
+                }
+            }            
+
+            SizeOfTrafNumber   = GetIntSize(_entries.Max(e => e.TrafNumber));
+            SizeOfTrunNumber   = GetIntSize(_entries.Max(e => e.TrunNumber));
+            SizeOfSampleNumber = GetIntSize(_entries.Max(e => e.SampleNumber));
+            Version            = has64BitEntry ? (byte)1 : (byte)0;
 
             base.SaveToStream(stream);
 
             stream.WriteBEUInt32(TrackID);
-            stream.Write(Reserved, 0, 3);
-            stream.WriteOneByte(_SizeOf);
+            stream.Write(_reserved, 0, 3);
+            stream.WriteOneByte(_sizeOf);
 
-            stream.WriteBEUInt32((uint)_Entries.Count);
-            foreach (var entry in _Entries)
+            stream.WriteBEUInt32((uint)_entries.Count);
+
+            foreach (var entry in _entries)
             {
                 if (Version == 0x01)
                 {
@@ -110,52 +130,71 @@ namespace MatrixIO.IO.Bmff.Boxes
                     stream.WriteBEUInt32((uint)entry.MoofOffset);
                 }
 
-                if (SizeOfTrafNumber == 1) stream.WriteOneByte((byte)entry.TrafNumber);
-                else if (SizeOfTrafNumber == 2) stream.WriteBEUInt16((ushort)entry.TrafNumber);
-                else if (SizeOfTrafNumber == 3) stream.WriteBEUInt24((uint)entry.TrafNumber);
-                else stream.WriteBEUInt32((uint)entry.TrafNumber);
+                switch (SizeOfTrafNumber)
+                {
+                    case 1: stream.WriteOneByte((byte)entry.TrafNumber); break;
+                    case 2: stream.WriteBEUInt16((ushort)entry.TrafNumber); break;
+                    case 3: stream.WriteBEUInt24((uint)entry.TrafNumber); break;
+                    default: stream.WriteBEUInt32((uint)entry.TrafNumber); break;
+                }
 
-                if (SizeOfTrunNumber == 1) stream.WriteOneByte((byte)entry.TrunNumber);
-                else if (SizeOfTrunNumber == 2) stream.WriteBEUInt16((ushort)entry.TrunNumber);
-                else if (SizeOfTrunNumber == 3) stream.WriteBEUInt24((uint)entry.TrunNumber);
-                else stream.WriteBEUInt32((uint)entry.TrunNumber);
+                switch (SizeOfTrunNumber)
+                {
+                    case 1: stream.WriteOneByte((byte)entry.TrunNumber); break;
+                    case 2: stream.WriteBEUInt16((ushort)entry.TrunNumber); break;
+                    case 3: stream.WriteBEUInt24((uint)entry.TrunNumber); break;
+                    default: stream.WriteBEUInt32((uint)entry.TrunNumber); break;
+                }
 
-                if (SizeOfSampleNumber == 1) stream.WriteOneByte((byte)entry.SampleNumber);
-                else if (SizeOfSampleNumber == 2) stream.WriteBEUInt16((ushort)entry.SampleNumber);
-                else if (SizeOfSampleNumber == 3) stream.WriteBEUInt24((uint)entry.SampleNumber);
-                else stream.WriteBEUInt32((uint)entry.SampleNumber);
+                switch (SizeOfSampleNumber)
+                {
+                    case 1: stream.WriteOneByte((byte)entry.SampleNumber); break;
+                    case 2: stream.WriteBEUInt16((ushort)entry.SampleNumber); break;
+                    case 3: stream.WriteBEUInt24((uint)entry.SampleNumber); break;
+                    default: stream.WriteBEUInt32((uint)entry.SampleNumber); break;
+                }
             }
         }
 
         public uint TrackID { get; set; }
-        private byte[] Reserved = new byte[4];
-
-        private byte _SizeOf;
+        
         public sbyte SizeOfTrafNumber
         {
-            get => (sbyte)(((_SizeOf & 0x30) >> 4) + 1);
+            get => (sbyte)(((_sizeOf & 0x30) >> 4) + 1);
             private set
             {
-                if (value < 1 || value > 4) throw new OverflowException("SizeOfTrafNumber must be a value between 1 and 4.");
-                _SizeOf = (byte)((_SizeOf & 0xCF) | (((SizeOfTrafNumber - 1) & 0x30) << 4));
+                if (value < 1 || value > 4)
+                {
+                    throw new OverflowException("SizeOfTrafNumber must be a value between 1 and 4.");
+                }
+
+                _sizeOf = (byte)((_sizeOf & 0xCF) | (((SizeOfTrafNumber - 1) & 0x30) << 4));
             }
         }
         public sbyte SizeOfTrunNumber
         {
-            get => (sbyte)(((_SizeOf & 0x30) >> 4) + 1);
+            get => (sbyte)(((_sizeOf & 0x30) >> 4) + 1);
             private set
             {
-                if (value < 1 || value > 4) throw new OverflowException("SizeOfTrunNumber must be a value between 1 and 4.");
-                _SizeOf = (byte)((_SizeOf & 0xF3) | ((SizeOfSampleNumber - 1) & 0x03));
+                if (value < 1 || value > 4)
+                {
+                    throw new OverflowException("SizeOfTrunNumber must be a value between 1 and 4.");
+                }
+
+                _sizeOf = (byte)((_sizeOf & 0xF3) | ((SizeOfSampleNumber - 1) & 0x03));
             }
         }
         public sbyte SizeOfSampleNumber
         {
-            get => (sbyte)(((_SizeOf & 0x30) >> 4) + 1);
+            get => (sbyte)(((_sizeOf & 0x30) >> 4) + 1);
             private set
             {
-                if (value < 1 || value > 4) throw new OverflowException("SizeOfSampleNumber must be a value between 1 and 4.");
-                _SizeOf = (byte)((_SizeOf & 0xFC) | ((SizeOfTrunNumber - 1) & 0x0C << 2));
+                if (value < 1 || value > 4)
+                {
+                    throw new OverflowException("SizeOfSampleNumber must be a value between 1 and 4.");
+                }
+
+                _sizeOf = (byte)((_sizeOf & 0xFC) | ((SizeOfTrunNumber - 1) & 0x0C << 2));
             }
         }
 
@@ -164,13 +203,16 @@ namespace MatrixIO.IO.Bmff.Boxes
             public TrackFragmentEntry() { }
 
             public ulong Time { get; set; }
+
             public ulong MoofOffset { get; set; }
+
             public uint TrafNumber { get; set; }
+
             public uint TrunNumber { get; set; }
+
             public uint SampleNumber { get; set; }
         }
 
-        private IList<TrackFragmentEntry> _Entries = new List<TrackFragmentEntry>();
-        public IList<TrackFragmentEntry> Entries => _Entries;
+        public IList<TrackFragmentEntry> Entries => _entries;
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackFragmentRandomAccessBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackFragmentRandomAccessBox.cs
@@ -75,19 +75,19 @@ namespace MatrixIO.IO.Bmff.Boxes
             uint MaxTrafNumber = (from entry in _Entries select entry.TrafNumber).Max();
             if (MaxTrafNumber > 16777215) SizeOfTrafNumber = 4;
             else if (MaxTrafNumber > UInt16.MaxValue) SizeOfTrafNumber = 3;
-            else if (MaxTrafNumber > Byte.MaxValue) SizeOfTrafNumber = 2;
+            else if (MaxTrafNumber > byte.MaxValue) SizeOfTrafNumber = 2;
             else SizeOfTrafNumber = 1;
 
             uint MaxTrunNumber = (from entry in _Entries select entry.TrunNumber).Max();
             if (MaxTrunNumber > 16777215) SizeOfTrunNumber = 4;
             else if (MaxTrunNumber > UInt16.MaxValue) SizeOfTrunNumber = 3;
-            else if (MaxTrunNumber > Byte.MaxValue) SizeOfTrunNumber = 2;
+            else if (MaxTrunNumber > byte.MaxValue) SizeOfTrunNumber = 2;
             else SizeOfTrunNumber = 1;
 
             uint MaxSampleNumber = (from entry in _Entries select entry.SampleNumber).Max();
             if (MaxSampleNumber > 16777215) SizeOfSampleNumber = 4;
             else if (MaxSampleNumber > UInt16.MaxValue) SizeOfSampleNumber = 3;
-            else if (MaxSampleNumber > Byte.MaxValue) SizeOfSampleNumber = 2;
+            else if (MaxSampleNumber > byte.MaxValue) SizeOfSampleNumber = 2;
             else SizeOfSampleNumber = 1;
 
             base.SaveToStream(stream);
@@ -133,10 +133,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         private byte _SizeOf;
         public sbyte SizeOfTrafNumber
         {
-            get
-            {
-                return (sbyte)(((_SizeOf & 0x30) >> 4) + 1);
-            }
+            get => (sbyte)(((_SizeOf & 0x30) >> 4) + 1);
             private set
             {
                 if (value < 1 || value > 4) throw new OverflowException("SizeOfTrafNumber must be a value between 1 and 4.");
@@ -145,10 +142,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         }
         public sbyte SizeOfTrunNumber
         {
-            get
-            {
-                return (sbyte)(((_SizeOf & 0x30) >> 4) + 1);
-            }
+            get => (sbyte)(((_SizeOf & 0x30) >> 4) + 1);
             private set
             {
                 if (value < 1 || value > 4) throw new OverflowException("SizeOfTrunNumber must be a value between 1 and 4.");
@@ -157,10 +151,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         }
         public sbyte SizeOfSampleNumber
         {
-            get
-            {
-                return (sbyte)(((_SizeOf & 0x30) >> 4) + 1);
-            }
+            get => (sbyte)(((_SizeOf & 0x30) >> 4) + 1);
             private set
             {
                 if (value < 1 || value > 4) throw new OverflowException("SizeOfSampleNumber must be a value between 1 and 4.");
@@ -180,12 +171,6 @@ namespace MatrixIO.IO.Bmff.Boxes
         }
 
         private IList<TrackFragmentEntry> _Entries = new List<TrackFragmentEntry>();
-        public IList<TrackFragmentEntry> Entries
-        {
-            get
-            {
-                return _Entries;
-            }
-        }
+        public IList<TrackFragmentEntry> Entries => _Entries;
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackHeaderBox.cs
@@ -9,15 +9,10 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("tkhd", "Track Header Box")]
     public sealed class TrackHeaderBox : FullBox
     {
-        private readonly int[] _matrix = new int[9] { 0x00010000, 0, 0, 0, 0x00010000, 0, 0, 0, 0x40000000 }; // Unity Matrix
-        private uint _reserved1;
-        private readonly uint[] _reserved2 = new uint[2];
-        private ushort _reserved3;
-
-        public TrackHeaderBox() 
+        public TrackHeaderBox()
             : base() { }
 
-        public TrackHeaderBox(Stream stream) 
+        public TrackHeaderBox(Stream stream)
             : base(stream) { }
 
         public DateTime CreationTime { get; set; }
@@ -26,7 +21,11 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public uint TrackID { get; set; }
 
+        private uint Reserved1 { get; set; }
+
         public ulong Duration { get; set; }
+
+        private uint[] Reserved2 { get; set; } = new uint[2];
 
         public short Layer { get; set; }
 
@@ -34,8 +33,9 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public short Volume { get; set; }
 
+        private ushort Reserved3 { get; set; }
 
-        public int[] Matrix => _matrix;
+        public int[] Matrix { get; set; } = new int[9] { 0x00010000, 0, 0, 0, 0x00010000, 0, 0, 0, 0x40000000 };  // Unity Matrix
 
         public uint Width { get; set; }
 
@@ -56,7 +56,7 @@ namespace MatrixIO.IO.Bmff.Boxes
                 CreationTime = MovieHeaderBox.Convert1904Time(stream.ReadBEUInt64());
                 ModificationTime = MovieHeaderBox.Convert1904Time(stream.ReadBEUInt64());
                 TrackID = stream.ReadBEUInt32();
-                _reserved1 = stream.ReadBEUInt32();
+                Reserved1 = stream.ReadBEUInt32();
                 Duration = stream.ReadBEUInt64();
             }
             else // if (Version == 0)
@@ -64,22 +64,22 @@ namespace MatrixIO.IO.Bmff.Boxes
                 CreationTime = MovieHeaderBox.Convert1904Time(stream.ReadBEUInt32());
                 ModificationTime = MovieHeaderBox.Convert1904Time(stream.ReadBEUInt32());
                 TrackID = stream.ReadBEUInt32();
-                _reserved1 = stream.ReadBEUInt32();
+                Reserved1 = stream.ReadBEUInt32();
                 Duration = stream.ReadBEUInt32();
             }
             for (int i = 0; i < 2; i++)
             {
-                _reserved2[0] = stream.ReadBEUInt32();
+                Reserved2[0] = stream.ReadBEUInt32();
             }
 
             Layer = stream.ReadBEInt16();
             AlternateGroup = stream.ReadBEInt16();
             Volume = stream.ReadBEInt16();
-            _reserved3 = stream.ReadBEUInt16();
+            Reserved3 = stream.ReadBEUInt16();
 
             for (int i = 0; i < 9; i++)
             {
-                _matrix[i] = stream.ReadBEInt32();
+                Matrix[i] = stream.ReadBEInt32();
             }
 
             Width = stream.ReadBEUInt32();
@@ -95,7 +95,7 @@ namespace MatrixIO.IO.Bmff.Boxes
                 stream.WriteBEUInt64(MovieHeaderBox.Convert1904Time(CreationTime));
                 stream.WriteBEUInt64(MovieHeaderBox.Convert1904Time(ModificationTime));
                 stream.WriteBEUInt32(TrackID);
-                stream.WriteBEUInt32(_reserved1);
+                stream.WriteBEUInt32(Reserved1);
                 stream.WriteBEUInt64(Duration);
             }
             else // if (Version == 0)
@@ -103,23 +103,23 @@ namespace MatrixIO.IO.Bmff.Boxes
                 stream.WriteBEUInt32((uint)MovieHeaderBox.Convert1904Time(CreationTime));
                 stream.WriteBEUInt32((uint)MovieHeaderBox.Convert1904Time(ModificationTime));
                 stream.WriteBEUInt32(TrackID);
-                stream.WriteBEUInt32(_reserved1);
+                stream.WriteBEUInt32(Reserved1);
                 stream.WriteBEUInt32((uint)Duration);
             }
 
             for (int i = 0; i < 2; i++)
             {
-                stream.WriteBEUInt32(_reserved2[i]);
+                stream.WriteBEUInt32(Reserved2[i]);
             }
 
             stream.WriteBEInt16(Layer);
             stream.WriteBEInt16(AlternateGroup);
             stream.WriteBEInt16(Volume);
-            stream.WriteBEUInt16(_reserved3);
+            stream.WriteBEUInt16(Reserved3);
 
             for (int i = 0; i < 9; i++)
             {
-                stream.WriteBEInt32(_matrix[i]);
+                stream.WriteBEInt32(Matrix[i]);
             }
 
             stream.WriteBEUInt32(Width);

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackHeaderBox.cs
@@ -9,8 +9,37 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("tkhd", "Track Header Box")]
     public sealed class TrackHeaderBox : FullBox
     {
-        public TrackHeaderBox() : base() { }
-        public TrackHeaderBox(Stream stream) : base(stream) { }
+        private readonly int[] _matrix = new int[9] { 0x00010000, 0, 0, 0, 0x00010000, 0, 0, 0, 0x40000000 }; // Unity Matrix
+        private uint _reserved1;
+        private readonly uint[] _reserved2 = new uint[2];
+        private ushort _reserved3;
+
+        public TrackHeaderBox() 
+            : base() { }
+
+        public TrackHeaderBox(Stream stream) 
+            : base(stream) { }
+
+        public DateTime CreationTime { get; set; }
+
+        public DateTime ModificationTime { get; set; }
+
+        public uint TrackID { get; set; }
+
+        public ulong Duration { get; set; }
+
+        public short Layer { get; set; }
+
+        public short AlternateGroup { get; set; }
+
+        public short Volume { get; set; }
+
+
+        public int[] Matrix => _matrix;
+
+        public uint Width { get; set; }
+
+        public uint Height { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -27,7 +56,7 @@ namespace MatrixIO.IO.Bmff.Boxes
                 CreationTime = MovieHeaderBox.Convert1904Time(stream.ReadBEUInt64());
                 ModificationTime = MovieHeaderBox.Convert1904Time(stream.ReadBEUInt64());
                 TrackID = stream.ReadBEUInt32();
-                _Reserved1 = stream.ReadBEUInt32();
+                _reserved1 = stream.ReadBEUInt32();
                 Duration = stream.ReadBEUInt64();
             }
             else // if (Version == 0)
@@ -35,15 +64,24 @@ namespace MatrixIO.IO.Bmff.Boxes
                 CreationTime = MovieHeaderBox.Convert1904Time(stream.ReadBEUInt32());
                 ModificationTime = MovieHeaderBox.Convert1904Time(stream.ReadBEUInt32());
                 TrackID = stream.ReadBEUInt32();
-                _Reserved1 = stream.ReadBEUInt32();
+                _reserved1 = stream.ReadBEUInt32();
                 Duration = stream.ReadBEUInt32();
             }
-            for (int i = 0; i < 2; i++) _reserved2[0] = stream.ReadBEUInt32();
+            for (int i = 0; i < 2; i++)
+            {
+                _reserved2[0] = stream.ReadBEUInt32();
+            }
+
             Layer = stream.ReadBEInt16();
             AlternateGroup = stream.ReadBEInt16();
             Volume = stream.ReadBEInt16();
-            _Reserved3 = stream.ReadBEUInt16();
-            for (int i = 0; i < 9; i++) _matrix[i] = stream.ReadBEInt32();
+            _reserved3 = stream.ReadBEUInt16();
+
+            for (int i = 0; i < 9; i++)
+            {
+                _matrix[i] = stream.ReadBEInt32();
+            }
+
             Width = stream.ReadBEUInt32();
             Height = stream.ReadBEUInt32();
         }
@@ -57,7 +95,7 @@ namespace MatrixIO.IO.Bmff.Boxes
                 stream.WriteBEUInt64(MovieHeaderBox.Convert1904Time(CreationTime));
                 stream.WriteBEUInt64(MovieHeaderBox.Convert1904Time(ModificationTime));
                 stream.WriteBEUInt32(TrackID);
-                stream.WriteBEUInt32(_Reserved1);
+                stream.WriteBEUInt32(_reserved1);
                 stream.WriteBEUInt64(Duration);
             }
             else // if (Version == 0)
@@ -65,34 +103,27 @@ namespace MatrixIO.IO.Bmff.Boxes
                 stream.WriteBEUInt32((uint)MovieHeaderBox.Convert1904Time(CreationTime));
                 stream.WriteBEUInt32((uint)MovieHeaderBox.Convert1904Time(ModificationTime));
                 stream.WriteBEUInt32(TrackID);
-                stream.WriteBEUInt32(_Reserved1);
+                stream.WriteBEUInt32(_reserved1);
                 stream.WriteBEUInt32((uint)Duration);
             }
-            for (int i = 0; i < 2; i++) stream.WriteBEUInt32(_reserved2[i]);
+
+            for (int i = 0; i < 2; i++)
+            {
+                stream.WriteBEUInt32(_reserved2[i]);
+            }
+
             stream.WriteBEInt16(Layer);
             stream.WriteBEInt16(AlternateGroup);
             stream.WriteBEInt16(Volume);
-            stream.WriteBEUInt16(_Reserved3);
-            for (int i = 0; i < 9; i++) stream.WriteBEInt32(_matrix[i]);
+            stream.WriteBEUInt16(_reserved3);
+
+            for (int i = 0; i < 9; i++)
+            {
+                stream.WriteBEInt32(_matrix[i]);
+            }
+
             stream.WriteBEUInt32(Width);
             stream.WriteBEUInt32(Height);
         }
-
-        public DateTime CreationTime { get; set; }
-        public DateTime ModificationTime { get; set; }
-        public uint TrackID { get; set; }
-        private uint _Reserved1;
-        public ulong Duration { get; set; }
-
-        private readonly uint[] _reserved2 = new uint[2];
-        public short Layer { get; set; }
-        public short AlternateGroup { get; set; }
-        public short Volume { get; set; }
-        private ushort _Reserved3;
-        private readonly int[] _matrix = new int[9] { 0x00010000, 0, 0, 0, 0x00010000, 0, 0, 0, 0x40000000 }; // Unity Matrix
-        public int[] Matrix => _matrix;
-
-        public uint Width { get; set; }
-        public uint Height { get; set; }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackHeaderBox.cs
@@ -7,7 +7,7 @@ namespace MatrixIO.IO.Bmff.Boxes
     /// Track Header Box ('tkhd')
     /// </summary>
     [Box("tkhd", "Track Header Box")]
-    public class TrackHeaderBox : FullBox
+    public sealed class TrackHeaderBox : FullBox
     {
         public TrackHeaderBox() : base() { }
         public TrackHeaderBox(Stream stream) : base(stream) { }
@@ -38,12 +38,12 @@ namespace MatrixIO.IO.Bmff.Boxes
                 _Reserved1 = stream.ReadBEUInt32();
                 Duration = stream.ReadBEUInt32();
             }
-            for (int i = 0; i < 2; i++) _Reserved2[0] = stream.ReadBEUInt32();
+            for (int i = 0; i < 2; i++) _reserved2[0] = stream.ReadBEUInt32();
             Layer = stream.ReadBEInt16();
             AlternateGroup = stream.ReadBEInt16();
             Volume = stream.ReadBEInt16();
             _Reserved3 = stream.ReadBEUInt16();
-            for (int i = 0; i < 9; i++) _Matrix[i] = stream.ReadBEInt32();
+            for (int i = 0; i < 9; i++) _matrix[i] = stream.ReadBEInt32();
             Width = stream.ReadBEUInt32();
             Height = stream.ReadBEUInt32();
         }
@@ -68,12 +68,12 @@ namespace MatrixIO.IO.Bmff.Boxes
                 stream.WriteBEUInt32(_Reserved1);
                 stream.WriteBEUInt32((uint)Duration);
             }
-            for(int i=0; i<2; i++) stream.WriteBEUInt32(_Reserved2[i]);
+            for (int i = 0; i < 2; i++) stream.WriteBEUInt32(_reserved2[i]);
             stream.WriteBEInt16(Layer);
             stream.WriteBEInt16(AlternateGroup);
             stream.WriteBEInt16(Volume);
             stream.WriteBEUInt16(_Reserved3);
-            for (int i = 0; i < 9; i++) stream.WriteBEInt32(_Matrix[i]);
+            for (int i = 0; i < 9; i++) stream.WriteBEInt32(_matrix[i]);
             stream.WriteBEUInt32(Width);
             stream.WriteBEUInt32(Height);
         }
@@ -84,13 +84,13 @@ namespace MatrixIO.IO.Bmff.Boxes
         private uint _Reserved1;
         public ulong Duration { get; set; }
 
-        private uint[] _Reserved2 = new uint[2];
+        private readonly uint[] _reserved2 = new uint[2];
         public short Layer { get; set; }
         public short AlternateGroup { get; set; }
         public short Volume { get; set; }
         private ushort _Reserved3;
-        private int[] _Matrix = new int[9] { 0x00010000, 0, 0, 0, 0x00010000, 0, 0, 0, 0x40000000 }; // Unity Matrix
-        public int[] Matrix => _Matrix;
+        private readonly int[] _matrix = new int[9] { 0x00010000, 0, 0, 0, 0x00010000, 0, 0, 0, 0x40000000 }; // Unity Matrix
+        public int[] Matrix => _matrix;
 
         public uint Width { get; set; }
         public uint Height { get; set; }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackRunBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackRunBox.cs
@@ -33,7 +33,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             if ((Flags & TrackRunFlags.SampleCompositionTimeOffsetsPresent) == TrackRunFlags.SampleCompositionTimeOffsetsPresent)
                 entryLength += 4;
 
-            return calculatedSize + (entryLength * (ulong)_Entries.Count);
+            return calculatedSize + (entryLength * (ulong)_entries.Count);
         }
 
         protected override void LoadFromStream(Stream stream)
@@ -60,7 +60,7 @@ namespace MatrixIO.IO.Bmff.Boxes
                 if ((Flags & TrackRunFlags.SampleCompositionTimeOffsetsPresent) == TrackRunFlags.SampleCompositionTimeOffsetsPresent)
                     entry.SampleCompositionTimeOffset = stream.ReadBEUInt32();
 
-                _Entries.Add(entry);
+                _entries.Add(entry);
             }
         }
 
@@ -68,7 +68,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             if (DataOffset.HasValue) Flags |= TrackRunFlags.DataOffsetPresent;
             if (FirstSampleFlags != null) Flags |= TrackRunFlags.FirstSampleFlagsPresent;
-            foreach (var entry in _Entries)
+            foreach (var entry in _entries)
             {
                 // TODO: There must be a better way... probably involves changing TrackRunEntry
                 if (entry.SampleDuration.HasValue) Flags |= TrackRunFlags.SampleDurationPresent;
@@ -78,7 +78,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             }
             base.SaveToStream(stream);
 
-            stream.WriteBEUInt32((uint)_Entries.Count);
+            stream.WriteBEUInt32((uint)_entries.Count);
 
             if (DataOffset.HasValue)
                 stream.WriteBEInt32(DataOffset.Value);
@@ -86,7 +86,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             if (FirstSampleFlags != null)
                 stream.WriteBEUInt32(FirstSampleFlags._flags);
 
-            foreach (TrackRunEntry entry in _Entries)
+            foreach (TrackRunEntry entry in _entries)
             {
                 if ((Flags & TrackRunFlags.SampleDurationPresent) == TrackRunFlags.SampleDurationPresent)
                     stream.WriteBEUInt32(entry.SampleDuration ?? 0);
@@ -108,10 +108,10 @@ namespace MatrixIO.IO.Bmff.Boxes
         public int? DataOffset { get; set; }
         public SampleFlags FirstSampleFlags { get; set; }
 
-        private IList<TrackRunEntry> _Entries = new List<TrackRunEntry>();
-        public IList<TrackRunEntry> Entries => _Entries;
+        private IList<TrackRunEntry> _entries = new List<TrackRunEntry>();
+        public IList<TrackRunEntry> Entries => _entries;
 
-        [FlagsAttribute]
+        [Flags]
         public enum TrackRunFlags : uint
         {
             DataOffsetPresent = 0x000001,
@@ -127,8 +127,11 @@ namespace MatrixIO.IO.Bmff.Boxes
             public TrackRunEntry() { }
 
             public uint? SampleDuration { get; set; }
+
             public uint? SampleSize { get; set; }
+
             public SampleFlags SampleFlags { get; set; }
+
             public uint? SampleCompositionTimeOffset { get; set; }
         }
     }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackRunBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackRunBox.cs
@@ -101,8 +101,8 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         private new TrackRunFlags Flags
         {
-            get => (TrackRunFlags)_Flags;
-            set => _Flags = (uint)value;
+            get => (TrackRunFlags)_flags;
+            set => _flags = (uint)value;
         }
 
         public int? DataOffset { get; set; }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackRunBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackRunBox.cs
@@ -10,8 +10,23 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("trun", "Track Run Box")]
     public sealed class TrackRunBox : FullBox, ITableBox<TrackRunBox.TrackRunEntry>
     {
-        public TrackRunBox() : base() { }
-        public TrackRunBox(Stream stream) : base(stream) { }
+        public TrackRunBox() 
+            : base() { }
+
+        public TrackRunBox(Stream stream) 
+            : base(stream) { }
+
+        private new TrackRunFlags Flags
+        {
+            get => (TrackRunFlags)_flags;
+            set => _flags = (uint)value;
+        }
+
+        public int? DataOffset { get; set; }
+
+        public SampleFlags FirstSampleFlags { get; set; }
+        
+        public IList<TrackRunEntry> Entries { get; } = new List<TrackRunEntry>();
 
         internal override ulong CalculateSize()
         {
@@ -33,7 +48,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             if ((Flags & TrackRunFlags.SampleCompositionTimeOffsetsPresent) == TrackRunFlags.SampleCompositionTimeOffsetsPresent)
                 entryLength += 4;
 
-            return calculatedSize + (entryLength * (ulong)_entries.Count);
+            return calculatedSize + (entryLength * (ulong)Entries.Count);
         }
 
         protected override void LoadFromStream(Stream stream)
@@ -60,7 +75,7 @@ namespace MatrixIO.IO.Bmff.Boxes
                 if ((Flags & TrackRunFlags.SampleCompositionTimeOffsetsPresent) == TrackRunFlags.SampleCompositionTimeOffsetsPresent)
                     entry.SampleCompositionTimeOffset = stream.ReadBEUInt32();
 
-                _entries.Add(entry);
+                Entries.Add(entry);
             }
         }
 
@@ -68,7 +83,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             if (DataOffset.HasValue) Flags |= TrackRunFlags.DataOffsetPresent;
             if (FirstSampleFlags != null) Flags |= TrackRunFlags.FirstSampleFlagsPresent;
-            foreach (var entry in _entries)
+            foreach (var entry in Entries)
             {
                 // TODO: There must be a better way... probably involves changing TrackRunEntry
                 if (entry.SampleDuration.HasValue) Flags |= TrackRunFlags.SampleDurationPresent;
@@ -78,7 +93,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             }
             base.SaveToStream(stream);
 
-            stream.WriteBEUInt32((uint)_entries.Count);
+            stream.WriteBEUInt32((uint)Entries.Count);
 
             if (DataOffset.HasValue)
                 stream.WriteBEInt32(DataOffset.Value);
@@ -86,7 +101,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             if (FirstSampleFlags != null)
                 stream.WriteBEUInt32(FirstSampleFlags._flags);
 
-            foreach (TrackRunEntry entry in _entries)
+            foreach (TrackRunEntry entry in Entries)
             {
                 if ((Flags & TrackRunFlags.SampleDurationPresent) == TrackRunFlags.SampleDurationPresent)
                     stream.WriteBEUInt32(entry.SampleDuration ?? 0);
@@ -98,18 +113,6 @@ namespace MatrixIO.IO.Bmff.Boxes
                     stream.WriteBEUInt32(entry.SampleCompositionTimeOffset ?? 0);
             }
         }
-
-        private new TrackRunFlags Flags
-        {
-            get => (TrackRunFlags)_flags;
-            set => _flags = (uint)value;
-        }
-
-        public int? DataOffset { get; set; }
-        public SampleFlags FirstSampleFlags { get; set; }
-
-        private IList<TrackRunEntry> _entries = new List<TrackRunEntry>();
-        public IList<TrackRunEntry> Entries => _entries;
 
         [Flags]
         public enum TrackRunFlags : uint

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/VideoMediaHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/VideoMediaHeaderBox.cs
@@ -8,8 +8,15 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("vmhd", "Video Media Header Box")]
     public sealed class VideoMediaHeaderBox : FullBox
     {
-        public VideoMediaHeaderBox() : base() { }
-        public VideoMediaHeaderBox(Stream stream) : base(stream) { }
+        public VideoMediaHeaderBox()
+            : base() { }
+
+        public VideoMediaHeaderBox(Stream stream) 
+            : base(stream) { }
+
+        public CompositionMode GraphicsMode { get; set; }
+
+        public Colour OpColour { get; set; }
 
         internal override ulong CalculateSize()
         {
@@ -33,10 +40,6 @@ namespace MatrixIO.IO.Bmff.Boxes
             stream.WriteBEUInt16(OpColour.Green);
             stream.WriteBEUInt16(OpColour.Blue);
         }
-
-        public CompositionMode GraphicsMode { get; set; }
-
-        public Colour OpColour { get; set; }
 
         public enum CompositionMode : ushort
         {

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/VideoMediaHeaderBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/VideoMediaHeaderBox.cs
@@ -35,6 +35,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         }
 
         public CompositionMode GraphicsMode { get; set; }
+
         public Colour OpColour { get; set; }
 
         public enum CompositionMode : ushort
@@ -42,12 +43,8 @@ namespace MatrixIO.IO.Bmff.Boxes
             Copy = 0,
         }
 
-        public class Colour
+        public readonly struct Colour
         {
-            public ushort Red { get; private set; }
-            public ushort Green { get; private set; }
-            public ushort Blue { get; private set; }
-
             public Colour(ushort red, ushort green, ushort blue)
             {
                 Red = red;
@@ -55,9 +52,15 @@ namespace MatrixIO.IO.Bmff.Boxes
                 Blue = blue;
             }
 
+            public ushort Red { get; }
+
+            public ushort Green { get; }
+
+            public ushort Blue { get; }
+
             public override string ToString()
             {
-                return string.Format("[0x{0:X4}, 0x{1:X4}, 0x{2:X4}]", Red, Green, Blue);
+                return $"[0x{Red:X4}, 0x{Green:X4}, 0x{Blue:X4}]";
             }
         }
     }

--- a/MatrixIO.IO.Bmff/IO/Bmff/FourCC.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/FourCC.cs
@@ -84,14 +84,23 @@ namespace MatrixIO.IO.Bmff
         {
             try
             {
-                string fourcc = Encoding.UTF8.GetString(GetBytes(), 0, 4);
+                string fourcc = Encoding.ASCII.GetString(GetBytes(), 0, 4);
+
                 bool hasControlChars = false;
-                foreach (char c in fourcc) if (char.IsControl(c)) hasControlChars = true;
+
+                foreach (char c in fourcc)
+                {
+                    if (char.IsControl(c))
+                    {
+                        hasControlChars = true;
+                    }
+                }
+
                 if (!hasControlChars) return fourcc;
             }
             catch (ArgumentException) { } // UTF8 conversion failed
 
-            return string.Format("0x{0:x8}", _FourCC);
+            return $"0x{_FourCC:x8}";
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/FullBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/FullBox.cs
@@ -6,30 +6,37 @@ namespace MatrixIO.IO.Bmff
 {
     public abstract class FullBox : Box
     {
-        public byte Version { get; set; }
-
-        protected uint _Flags;
-        public BitArray Flags 
-        { 
-            get 
-            {
-                byte[] flagBytes32 = BitConverter.GetBytes(_Flags.HostToNetworkOrder());
-                byte[] flagBytes24 = new byte[3];
-                Buffer.BlockCopy(flagBytes32, 1, flagBytes24, 0, 3);
-                return new BitArray(flagBytes24); 
-            } 
-        }
-
+        protected uint _flags;
+        
         protected FullBox() : this(0) { }
-        protected FullBox(byte version, uint flags = 0) : base() 
+
+        protected FullBox(byte version, uint flags = 0) 
+            : base() 
         {
-            if ((flags & 0xFF000000) > 0) throw new FormatException("Box flags must be 24 bits.");
+            if ((flags & 0xFF000000) > 0)
+            {
+                throw new FormatException("Box flags must be 24 bits.");
+            }
 
             Version = version;
-            _Flags = flags;
+            _flags = flags;
         }
         
-        protected FullBox(Stream stream) : base(stream) { }
+        protected FullBox(Stream stream)
+            : base(stream) { }
+
+        public byte Version { get; set; }
+
+        public BitArray Flags
+        {
+            get
+            {
+                byte[] flagBytes32 = BitConverter.GetBytes(_flags.HostToNetworkOrder());
+                byte[] flagBytes24 = new byte[3];
+                Buffer.BlockCopy(flagBytes32, 1, flagBytes24, 0, 3);
+                return new BitArray(flagBytes24);
+            }
+        }
 
         internal override ulong CalculateSize()
         {
@@ -41,7 +48,7 @@ namespace MatrixIO.IO.Bmff
             base.LoadFromStream(stream);
 
             Version = stream.ReadOneByte();
-            _Flags = stream.ReadBEUInt24();
+            _flags = stream.ReadBEUInt24();
         }
 
         protected override void SaveToStream(Stream stream)
@@ -49,7 +56,7 @@ namespace MatrixIO.IO.Bmff
             base.SaveToStream(stream);
 
             stream.WriteOneByte(Version);
-            stream.WriteBEUInt24(_Flags);
+            stream.WriteBEUInt24(_flags);
         }
     }
 }

--- a/MatrixIO.IO.MpegTs/IO/MpegTs/PesPacket.cs
+++ b/MatrixIO.IO.MpegTs/IO/MpegTs/PesPacket.cs
@@ -193,7 +193,6 @@ namespace MatrixIO.IO.MpegTs
             set => _header = (byte)((_header & 0xFE) | (value ? 0x01 : 0));
         }
 
-
         // 1 bit HasPTS
         private bool HasPTS
         {
@@ -228,18 +227,21 @@ namespace MatrixIO.IO.MpegTs
             get => (_flags & 0x08) > 0;
             set => _flags = (byte)((_flags & 0xF7) | (value ? 0x08 : 0));
         }
+
         // 1 bit AdditionalCopyInfoFlag
         private bool HasAdditionalCopyInfo
         {
             get => (_flags & 0x04) > 0;
             set => _flags = (byte)((_flags & 0xFB) | (value ? 0x04 : 0));
         }
+
         // 1 bit CRCFlag
         private bool HasCRC
         {
             get => (_flags & 0x02) > 0;
             set => _flags = (byte)((_flags & 0xFD) | (value ? 0x02 : 0));
         }
+
         // 1 bit ExtensionFlag
         private bool HasExtension
         {

--- a/MatrixIO.IO.MpegTs/IO/MpegTs/TsPacket.cs
+++ b/MatrixIO.IO.MpegTs/IO/MpegTs/TsPacket.cs
@@ -98,10 +98,10 @@ namespace MatrixIO.IO.MpegTs
         /// </summary>
         public byte ContinuityCounter
         {
-            get { return (byte)(_header2 & 0x0F); }
+            get => (byte)(_header2 & 0x0F);
             set
             {
-                Debug.Assert((int) value < 16, "ContinuityCounter must be in the range of 0 to 15.");
+                Debug.Assert((int)value < 16, "ContinuityCounter must be in the range of 0 to 15.");
                 _header2 = (byte)((_header2 & 0xF0) | (value & 0x0F));
             }
         }

--- a/MatrixIO.IO/Fraction.cs
+++ b/MatrixIO.IO/Fraction.cs
@@ -167,10 +167,10 @@ namespace MatrixIO
         }
 
         #region Object overrides
+
         public override bool Equals(object obj)
         {
-            if (obj == null || !(obj is Fraction)) return false;
-            return Equals((Fraction)obj);
+            return obj is Fraction other && Equals(other);
         }
 
         public override int GetHashCode()

--- a/MatrixIO.IO/IO/ByteRange.cs
+++ b/MatrixIO.IO/IO/ByteRange.cs
@@ -2,7 +2,7 @@
 
 namespace MatrixIO.IO
 {
-    public readonly struct ByteRange
+    public readonly struct ByteRange : IEquatable<ByteRange>
     {
         public ByteRange(long start, long end)
         {
@@ -88,9 +88,15 @@ namespace MatrixIO.IO
             else if (a < b) return true;
             else return false;
         }
+
+        public bool Equals(ByteRange other)
+        {
+            return Start == other.Start && End == other.End;
+        }
+
         public override bool Equals(object obj)
         {
-            return base.Equals(obj) && ((ByteRange)obj).Start == Start && ((ByteRange)obj).End == End;
+            return obj is ByteRange other && Equals(other);
         }
 
         private const long TOP_MASK = unchecked((long)0xFFFFFFFF00000000);

--- a/MatrixIO.IO/IO/ByteRange.cs
+++ b/MatrixIO.IO/IO/ByteRange.cs
@@ -56,32 +56,38 @@ namespace MatrixIO.IO
         }
 
         #region Operator Overloads
+
         public static bool operator <(ByteRange a, ByteRange b)
         {
             if (a.Start > b.Start && a.End <= b.End) return true;
             else if (a.Start >= b.Start && a.End < b.End) return true;
             else return false;
         }
+
         public static bool operator >(ByteRange a, ByteRange b)
         {
             if (a.Start < b.Start && a.End >= b.End) return true;
             else if (a.Start <= b.Start && a.End > b.End) return true;
             else return false;
         }
+
         public static bool operator ==(ByteRange a, ByteRange b)
         {
             return a.Equals(b);
         }
+
         public static bool operator !=(ByteRange a, ByteRange b)
         {
             return !(a == b);
         }
+
         public static bool operator >=(ByteRange a, ByteRange b)
         {
             if (a == b) return true;
             else if (a > b) return true;
             else return false;
         }
+
         public static bool operator <=(ByteRange a, ByteRange b)
         {
             if (a == b) return true;


### PR DESCRIPTION
A quick cleanup pass.

- Makes register sized classes structures
- Uses expression bodies in trival contexts
- Move properties above methods
- Small formatting improvements
