### PR TITLE
Improve CQ3

### DIFF
--- a/BMFF.sln
+++ b/BMFF.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 15.0.27004.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MatrixIO.IO.Bmff", "MatrixIO.IO.Bmff\MatrixIO.IO.Bmff.csproj", "{4A565C90-1850-4A15-816D-E332981735AB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MatrixIO.IO.MpegTs", "MatrixIO.IO.MpegTs\MatrixIO.IO.MpegTs.csproj", "{B2B26824-21F0-4576-BD4A-104EDD61E180}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MatrixIO.IO.MpegTs", "MatrixIO.IO.MpegTs\MatrixIO.IO.MpegTs.csproj", "{B2B26824-21F0-4576-BD4A-104EDD61E180}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MatrixIO.IO.Ebml", "MatrixIO.IO.Ebml\MatrixIO.IO.Ebml.csproj", "{74FCBCE0-CF0D-49A4-9EB7-A172D4865E94}"
 EndProject
@@ -27,6 +27,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Specifications", "Specifica
 		MatrixIO.IO.Bmff\Specifications\qtff.pdf = MatrixIO.IO.Bmff\Specifications\qtff.pdf
 		MatrixIO.IO.Bmff\Specifications\video_file_format_spec_v10_1.pdf = MatrixIO.IO.Bmff\Specifications\video_file_format_spec_v10_1.pdf
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{E42E2C99-B793-430E-9FF6-E4861A427A99}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MatrixIO.IO.Bmff.Tests", "MatrixIO.IO.Bmff.Tests\MatrixIO.IO.Bmff.Tests.csproj", "{CB82E742-9DBD-40C0-BFED-069B41515C70}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -78,9 +82,24 @@ Global
 		{EDC16014-ECA3-4B93-A849-B81EAC369DD2}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{EDC16014-ECA3-4B93-A849-B81EAC369DD2}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{EDC16014-ECA3-4B93-A849-B81EAC369DD2}.Release|x86.ActiveCfg = Release|Any CPU
+		{CB82E742-9DBD-40C0-BFED-069B41515C70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB82E742-9DBD-40C0-BFED-069B41515C70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB82E742-9DBD-40C0-BFED-069B41515C70}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{CB82E742-9DBD-40C0-BFED-069B41515C70}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{CB82E742-9DBD-40C0-BFED-069B41515C70}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CB82E742-9DBD-40C0-BFED-069B41515C70}.Debug|x86.Build.0 = Debug|Any CPU
+		{CB82E742-9DBD-40C0-BFED-069B41515C70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB82E742-9DBD-40C0-BFED-069B41515C70}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB82E742-9DBD-40C0-BFED-069B41515C70}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{CB82E742-9DBD-40C0-BFED-069B41515C70}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{CB82E742-9DBD-40C0-BFED-069B41515C70}.Release|x86.ActiveCfg = Release|Any CPU
+		{CB82E742-9DBD-40C0-BFED-069B41515C70}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{CB82E742-9DBD-40C0-BFED-069B41515C70} = {E42E2C99-B793-430E-9FF6-E4861A427A99}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9CAADDC4-B2C2-40A2-8363-F093866C2C40}

--- a/MatrixIO.IO.Bmff.Tests/Boxes/SampleSizeBoxTests.cs
+++ b/MatrixIO.IO.Bmff.Tests/Boxes/SampleSizeBoxTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Xunit;
+
+namespace MatrixIO.IO.Bmff.Boxes.Tests
+{
+    public class SampleSizeBoxTests
+    {
+        [Fact]
+        public void CanRoundtrip()
+        {
+            var entries = new[] {
+                new SampleSizeBox.SampleSizeEntry(977),
+                new SampleSizeBox.SampleSizeEntry(938),
+                new SampleSizeBox.SampleSizeEntry(939),
+                new SampleSizeBox.SampleSizeEntry(938),
+                new SampleSizeBox.SampleSizeEntry(934),
+                new SampleSizeBox.SampleSizeEntry(945),
+                new SampleSizeBox.SampleSizeEntry(948),
+                new SampleSizeBox.SampleSizeEntry(956),
+                new SampleSizeBox.SampleSizeEntry(955),
+                new SampleSizeBox.SampleSizeEntry(930),
+                new SampleSizeBox.SampleSizeEntry(933),
+                new SampleSizeBox.SampleSizeEntry(934),
+                new SampleSizeBox.SampleSizeEntry(972),
+                new SampleSizeBox.SampleSizeEntry(977),
+                new SampleSizeBox.SampleSizeEntry(958),
+                new SampleSizeBox.SampleSizeEntry(949),
+                new SampleSizeBox.SampleSizeEntry(962),
+                new SampleSizeBox.SampleSizeEntry(848)
+            };
+
+            var box = new SampleSizeBox
+            {
+                Entries = entries
+            };
+
+            var deserialized = (SampleSizeBox)TestHelper.Decode(TestHelper.Encode(box));
+
+            Assert.Equal(0,     deserialized.Version);
+            Assert.Equal(0u,    deserialized.SampleSize); // variable
+            Assert.Equal(18u,   deserialized.SampleCount);
+
+            Assert.Equal(box.Entries, deserialized.Entries);
+        }
+    }
+}

--- a/MatrixIO.IO.Bmff.Tests/Helpers/TestHelper.cs
+++ b/MatrixIO.IO.Bmff.Tests/Helpers/TestHelper.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+
+namespace MatrixIO.IO.Bmff
+{
+    public class TestHelper
+    {
+        public static byte[] Encode(Box box)
+        {
+            using (var ms = new MemoryStream())
+            {
+                box.ToStream(ms);
+
+                return ms.ToArray();
+            }
+        }
+
+        public static Box Decode(byte[] data)
+        {
+            using (var ms = new MemoryStream(data))
+            {
+                return Box.FromStream(ms);
+            }
+        }
+    }
+
+}

--- a/MatrixIO.IO.Bmff.Tests/MatrixIO.IO.Bmff.Tests.csproj
+++ b/MatrixIO.IO.Bmff.Tests/MatrixIO.IO.Bmff.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MatrixIO.IO.Bmff\MatrixIO.IO.Bmff.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/ChunkLargeOffsetBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/ChunkLargeOffsetBox.cs
@@ -9,12 +9,19 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("co64", "Chunk Large Offset Box")]
     public sealed class ChunkLargeOffsetBox : FullBox, ITableBox<ChunkLargeOffsetBox.ChunkLargeOffsetEntry>
     {
-        public ChunkLargeOffsetBox() : base() { }
-        public ChunkLargeOffsetBox(Stream stream) : base(stream) { }
+        public ChunkLargeOffsetBox()
+            : base() { }
+
+        public ChunkLargeOffsetBox(Stream stream) 
+            : base(stream) { }
+
+        public ChunkLargeOffsetEntry[] Entries { get; set; }
+
+        public int EntryCount => Entries.Length;
 
         internal override ulong CalculateSize()
         {
-            return base.CalculateSize() + 4 + ((ulong)Entries.Count * 8);
+            return base.CalculateSize() + 4 + ((ulong)Entries.Length * 8);
         }
 
         protected override void LoadFromStream(Stream stream)
@@ -23,9 +30,11 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             uint entryCount = stream.ReadBEUInt32();
 
+            Entries = new ChunkLargeOffsetEntry[entryCount];
+
             for (uint i = 0; i < entryCount; i++)
             {
-                Entries.Add(new ChunkLargeOffsetEntry(stream.ReadBEUInt64()));
+                Entries[i] = new ChunkLargeOffsetEntry(stream.ReadBEUInt64());
             }
         }
 
@@ -33,17 +42,15 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.SaveToStream(stream);
 
-            stream.WriteBEUInt32((uint)Entries.Count);
+            stream.WriteBEUInt32((uint)Entries.Length);
 
-            foreach (ChunkLargeOffsetEntry chunkLargeOffsetEntry in Entries)
+            for (int i = 0; i < Entries.Length; i++)
             {
-                stream.WriteBEUInt64(chunkLargeOffsetEntry.ChunkOffset);
+                ref ChunkLargeOffsetEntry entry = ref Entries[i];
+
+                stream.WriteBEUInt64(entry.ChunkOffset);
             }
         }
-
-        public IList<ChunkLargeOffsetEntry> Entries { get; } = new List<ChunkLargeOffsetEntry>();
-
-        public int EntryCount => Entries.Count;
 
         public readonly struct ChunkLargeOffsetEntry
         {
@@ -58,6 +65,7 @@ namespace MatrixIO.IO.Bmff.Boxes
             {
                 return entry.ChunkOffset;
             }
+
             public static implicit operator ChunkLargeOffsetEntry(ulong sampleDependency)
             {
                 return new ChunkLargeOffsetEntry(sampleDependency);

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/ChunkOffsetBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/ChunkOffsetBox.cs
@@ -12,9 +12,13 @@ namespace MatrixIO.IO.Bmff.Boxes
         public ChunkOffsetBox() : base() { }
         public ChunkOffsetBox(Stream stream) : base(stream) { }
 
+        public ChunkOffsetEntry[] Entries { get; set; }
+
+        public int EntryCount => Entries.Length;
+
         internal override ulong CalculateSize()
         {
-            return base.CalculateSize() + 4 + ((ulong)Entries.Count * 4);
+            return base.CalculateSize() + 4 + ((ulong)Entries.Length * 4);
         }
 
         protected override void LoadFromStream(Stream stream)
@@ -23,9 +27,11 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             uint entryCount = stream.ReadBEUInt32();
 
+            Entries = new ChunkOffsetEntry[entryCount];
+
             for (uint i = 0; i < entryCount; i++)
             {
-                Entries.Add(new ChunkOffsetEntry(stream.ReadBEUInt32()));
+                Entries[i] = new ChunkOffsetEntry(stream.ReadBEUInt32());
             }
         }
 
@@ -33,17 +39,15 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.SaveToStream(stream);
 
-            stream.WriteBEUInt32((uint)Entries.Count);
+            stream.WriteBEUInt32((uint)Entries.Length);
 
-            foreach (ChunkOffsetEntry chunkOffsetEntry in Entries)
+            for (int i = 0; i < Entries.Length; i++)
             {
-                stream.WriteBEUInt32(chunkOffsetEntry.ChunkOffset);
+                ref ChunkOffsetEntry entry = ref Entries[i];
+
+                stream.WriteBEUInt32(entry.ChunkOffset);
             }
         }
-
-        public IList<ChunkOffsetEntry> Entries { get; } = new List<ChunkOffsetEntry>();
-
-        public int EntryCount => Entries.Count;
 
         public readonly struct ChunkOffsetEntry
         {

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/CompositionOffsetBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/CompositionOffsetBox.cs
@@ -15,13 +15,13 @@ namespace MatrixIO.IO.Bmff.Boxes
         public CompositionOffsetBox(Stream stream) 
             : base(stream) { }
 
-        public IList<CompositionOffsetEntry> Entries { get; } = new List<CompositionOffsetEntry>();
+        public CompositionOffsetEntry[] Entries { get; set; }
 
-        public int EntryCount => Entries.Count;
+        public int EntryCount => Entries.Length;
 
         internal override ulong CalculateSize()
         {
-            return base.CalculateSize() + 4 + ((ulong)Entries.Count * (4 + 4));
+            return base.CalculateSize() + 4 + ((ulong)Entries.Length * (4 + 4));
         }
 
         protected override void LoadFromStream(Stream stream)
@@ -30,12 +30,14 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             uint entryCount = stream.ReadBEUInt32();
 
+            Entries = new CompositionOffsetEntry[entryCount];
+
             for (uint i = 0; i < entryCount; i++)
             {
-                Entries.Add(new CompositionOffsetEntry(
+                Entries[i] = new CompositionOffsetEntry(
                     sampleCount: stream.ReadBEUInt32(),
                     sampleOffset: stream.ReadBEUInt32()
-                ));
+                );
             }
         }
 
@@ -43,12 +45,14 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.SaveToStream(stream);
 
-            stream.WriteBEUInt32((uint)Entries.Count);
+            stream.WriteBEUInt32((uint)Entries.Length);
 
-            foreach (CompositionOffsetEntry CompositionOffsetEntry in Entries)
+            for (int i = 0; i < Entries.Length; i++)
             {
-                stream.WriteBEUInt32(CompositionOffsetEntry.SampleCount);
-                stream.WriteBEUInt32(CompositionOffsetEntry.SampleOffset);
+                ref CompositionOffsetEntry entry = ref Entries[i];
+
+                stream.WriteBEUInt32(entry.SampleCount);
+                stream.WriteBEUInt32(entry.SampleOffset);
             }
         }
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataEntryUrlBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/DataEntryUrlBox.cs
@@ -9,11 +9,16 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("url ", "Data Entry Url Box")]
     public sealed class DataEntryUrlBox : FullBox
     {
-        public DataEntryUrlBox() 
+        public DataEntryUrlBox()
             : base() { }
 
-        public DataEntryUrlBox(Stream stream) 
+        public DataEntryUrlBox(Stream stream)
             : base(stream) { }
+
+        public DataEntryUrlBox(string location)
+        {
+            Location = location;
+        }
 
         public string Location { get; set; }
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/EditListBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/EditListBox.cs
@@ -9,13 +9,20 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("elst", "Edit List Box")]
     public sealed class EditListBox : FullBox, ITableBox<EditListBox.EditListEntry>
     {
-        public EditListBox() : base() { }
-        public EditListBox(Stream stream) : base(stream) { }
+        public EditListBox() 
+            : base() { }
+
+        public EditListBox(Stream stream) 
+            : base(stream) { }
+
+        public EditListEntry[] Entries { get; set; }
+
+        public int EntryCount => Entries.Length;
 
         internal override ulong CalculateSize()
         {
             ulong entryLength = (ulong)(Version == 1 ? 8 + 8 : 4 + 4) + 2 + 2;
-            return base.CalculateSize() + 4 + (entryLength * (ulong)Entries.Count);
+            return base.CalculateSize() + 4 + (entryLength * (ulong)Entries.Length);
         }
 
         protected override void LoadFromStream(Stream stream)
@@ -24,23 +31,30 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             uint entryCount = stream.ReadBEUInt32();
 
+            this.Entries = new EditListEntry[entryCount];
+
             for (uint i = 0; i < entryCount; i++)
             {
-                var entry = new EditListEntry();
+                ulong segmentDuration;
+                long mediaTime;
+                short mediaRateInteger;
+                short mediaRateFraction;
+
                 if (Version == 1)
                 {
-                    entry.SegmentDuration = stream.ReadBEUInt64();
-                    entry.MediaTime = stream.ReadBEInt64();
+                    segmentDuration = stream.ReadBEUInt64();
+                    mediaTime = stream.ReadBEInt64();
                 }
                 else
                 {
-                    entry.SegmentDuration = stream.ReadBEUInt32();
-                    entry.MediaTime = stream.ReadBEInt32();
+                    segmentDuration = stream.ReadBEUInt32();
+                    mediaTime = stream.ReadBEInt32();
                 }
-                entry.MediaRateInteger = stream.ReadBEInt16();
-                entry.MediaRateFraction = stream.ReadBEInt16();
 
-                Entries.Add(entry);
+                mediaRateInteger = stream.ReadBEInt16();
+                mediaRateFraction = stream.ReadBEInt16();
+
+                Entries[i] = new EditListEntry(segmentDuration, mediaTime, mediaRateInteger, mediaRateFraction);
             }
         }
 
@@ -48,10 +62,12 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.SaveToStream(stream);
 
-            stream.WriteBEInt32(Entries.Count);
+            stream.WriteBEInt32(Entries.Length);
 
-            foreach (EditListEntry entry in Entries)
+            for (int i = 0; i < Entries.Length; i++)
             {
+                ref EditListEntry entry = ref Entries[i];
+
                 if (Version == 1)
                 {
                     stream.WriteBEUInt64(entry.SegmentDuration);
@@ -62,24 +78,33 @@ namespace MatrixIO.IO.Bmff.Boxes
                     stream.WriteBEUInt32((uint)entry.SegmentDuration);
                     stream.WriteBEInt32((int)entry.MediaTime);
                 }
+
                 stream.WriteBEInt16(entry.MediaRateInteger);
                 stream.WriteBEInt16(entry.MediaRateFraction);
             }
         }
-
-        public IList<EditListEntry> Entries { get; } = new List<EditListEntry>();
-
-        public int EntryCount => Entries.Count;
-
-        public class EditListEntry
+        
+        public readonly struct EditListEntry
         {
-            public EditListEntry() { }
+            public EditListEntry(
+                ulong segmentDuration,
+                long mediaTime,
+                short mediaRateInteger,
+                short mediaRateFraction)
+            {
+                SegmentDuration = segmentDuration;
+                MediaTime = mediaTime;
+                MediaRateInteger = mediaRateInteger;
+                MediaRateFraction = mediaRateFraction;
+            }
 
-            public ulong SegmentDuration { get; set; }
-            public long MediaTime { get; set; }
+            public ulong SegmentDuration { get; }
 
-            public short MediaRateInteger { get; set; }
-            public short MediaRateFraction { get; set; }
+            public long MediaTime { get; }
+
+            public short MediaRateInteger { get; }
+
+            public short MediaRateFraction { get; }
         }
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/Jp2/BitsPerComponentBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/Jp2/BitsPerComponentBox.cs
@@ -15,36 +15,44 @@ namespace MatrixIO.IO.Bmff.Boxes
         public BitsPerComponentBox(Stream stream) 
             : base(stream) { }
 
-        public IList<ComponentBitsEntry> Entries { get; } = new List<ComponentBitsEntry>();
+        public ComponentBitsEntry[] Entries { get; set; }
 
-        public int EntryCount => Entries.Count;
+        public int EntryCount => Entries.Length;
 
         internal override ulong CalculateSize()
         {
-            return base.CalculateSize() + (ulong)Entries.Count;
+            return base.CalculateSize() + (ulong)Entries.Length;
         }
 
         protected override void LoadFromStream(Stream stream)
         {
             base.LoadFromStream(stream);
 
+            var entries = new List<ComponentBitsEntry>();
+
             // TODO: Read in as a byte array and convert to List<ComponentBitsEntry>
             while (stream.Position < (long)(Offset + EffectiveSize))
             {
                 byte b = stream.ReadOneByte();
-                Entries.Add(new ComponentBitsEntry(b));
+
+                entries.Add(new ComponentBitsEntry(b));
             }
+
+            Entries = entries.ToArray();
         }
 
         protected override void SaveToStream(Stream stream)
         {
             base.SaveToStream(stream);
 
-            // TODO: Convert to byte[] and write all at once.
-            foreach (ComponentBitsEntry entry in Entries)
+            var data = new byte[Entries.Length];
+
+            for (var i = 0; i < Entries.Length; i++)
             {
-                stream.WriteOneByte(entry.ComponentBits);
+                data[i] = Entries[i].ComponentBits;
             }
+
+            stream.Write(data, 0, data.Length);
         }
 
         public readonly struct ComponentBitsEntry

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleDependencyTypeBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleDependencyTypeBox.cs
@@ -15,22 +15,26 @@ namespace MatrixIO.IO.Bmff.Boxes
         public SampleDependencyTypeBox(Stream stream) 
             : base(stream) { }
 
-        public IList<SampleDependencyEntry> Entries { get; } = new List<SampleDependencyEntry>();
+        public SampleDependencyEntry[] Entries { get; set; }
 
         internal override ulong CalculateSize()
         {
-            return base.CalculateSize() + (ulong)Entries.Count;
+            return base.CalculateSize() + (ulong)Entries.Length;
         }
 
         protected override void LoadFromStream(Stream stream)
         {
             base.LoadFromStream(stream);
 
+            var entries = new List<SampleDependencyEntry>();
+
             while (stream.Position < (long)(Offset + EffectiveSize))
             {
                 byte b = stream.ReadOneByte();
-                Entries.Add(new SampleDependencyEntry(b));
+                entries.Add(new SampleDependencyEntry(b));
             }
+
+            Entries = entries.ToArray();
         }
 
         protected override void SaveToStream(Stream stream)

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleSizeBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleSizeBox.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 
 namespace MatrixIO.IO.Bmff.Boxes
 {
@@ -19,15 +18,15 @@ namespace MatrixIO.IO.Bmff.Boxes
 
         public uint SampleSize { get; set; }
 
-        public uint SampleCount => (SampleSize == 0) ? (uint)Entries.Count : _sampleCount;
+        public uint SampleCount => (SampleSize == 0) ? (uint)Entries.Length : _sampleCount;
 
-        public IList<SampleSizeEntry> Entries { get; } = new List<SampleSizeEntry>();
+        public SampleSizeEntry[] Entries { get; set; }
 
-        public uint EntryCount => (uint)Entries.Count;
+        public uint EntryCount => (uint)Entries.Length;
 
         internal override ulong CalculateSize()
         {
-            return base.CalculateSize() + 4 + 4 + ((ulong)Entries.Count * 4);
+            return base.CalculateSize() + 4 + 4 + ((ulong)Entries.Length * 4);
         }
 
         protected override void LoadFromStream(Stream stream)
@@ -37,11 +36,13 @@ namespace MatrixIO.IO.Bmff.Boxes
             SampleSize = stream.ReadBEUInt32();
             _sampleCount = stream.ReadBEUInt32();
 
+            Entries = new SampleSizeEntry[_sampleCount];
+
             if (SampleSize == 0)
             {
-                for (uint i = 0; i < _sampleCount; i++)
+                for (int i = 0; i < _sampleCount; i++)
                 {
-                    Entries.Add(new SampleSizeEntry(stream.ReadBEUInt32()));
+                    Entries[i] = new SampleSizeEntry(stream.ReadBEUInt32());
                 }
             }
         }

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleToChunkBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SampleToChunkBox.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 
 namespace MatrixIO.IO.Bmff.Boxes
 {
@@ -15,13 +14,13 @@ namespace MatrixIO.IO.Bmff.Boxes
         public SampleToChunkBox(Stream stream) 
             : base(stream) { }
 
-        public IList<SampleToChunkEntry> Entries { get; } = new List<SampleToChunkEntry>();
+        public SampleToChunkEntry[] Entries { get; set; }
 
-        public int EntryCount => Entries.Count;
+        public int EntryCount => Entries.Length;
 
         internal override ulong CalculateSize()
         {
-            return base.CalculateSize() + 4 + ((ulong)Entries.Count * (4 + 4 + 4));
+            return base.CalculateSize() + 4 + ((ulong)Entries.Length * (4 + 4 + 4));
         }
 
         protected override void LoadFromStream(Stream stream)
@@ -30,13 +29,15 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             uint entryCount = stream.ReadBEUInt32();
 
+            Entries = new SampleToChunkEntry[entryCount];
+
             for (uint i = 0; i < entryCount; i++)
             {
-                Entries.Add(new SampleToChunkEntry(
+                Entries[i] = new SampleToChunkEntry(
                     firstChunk: stream.ReadBEUInt32(),
                     samplesPerChunk: stream.ReadBEUInt32(),
                     sampleDescriptionIndex: stream.ReadBEUInt32()
-                ));
+                );
             }
         }
 
@@ -44,13 +45,15 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.SaveToStream(stream);
 
-            stream.WriteBEUInt32((uint)Entries.Count);
+            stream.WriteBEUInt32((uint)Entries.Length);
 
-            foreach (SampleToChunkEntry SampleToChunkEntry in Entries)
+            for (int i = 0; i < Entries.Length; i++)
             {
-                stream.WriteBEUInt32(SampleToChunkEntry.FirstChunk);
-                stream.WriteBEUInt32(SampleToChunkEntry.SamplesPerChunk);
-                stream.WriteBEUInt32(SampleToChunkEntry.SampleDescriptionIndex);
+                ref SampleToChunkEntry entry = ref Entries[i];
+
+                stream.WriteBEUInt32(entry.FirstChunk);
+                stream.WriteBEUInt32(entry.SamplesPerChunk);
+                stream.WriteBEUInt32(entry.SampleDescriptionIndex);
             }
         }
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SyncSampleBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/SyncSampleBox.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 
 namespace MatrixIO.IO.Bmff.Boxes
 {
@@ -9,19 +8,19 @@ namespace MatrixIO.IO.Bmff.Boxes
     [Box("stss", "Sync Sample Box")]
     public sealed class SyncSampleBox : FullBox, ITableBox<SyncSampleBox.SyncSampleEntry>
     {
-        public SyncSampleBox() 
+        public SyncSampleBox()
             : base() { }
 
-        public SyncSampleBox(Stream stream) 
+        public SyncSampleBox(Stream stream)
             : base(stream) { }
 
-        public IList<SyncSampleEntry> Entries { get; } = new List<SyncSampleEntry>();
+        public SyncSampleEntry[] Entries { get; set; }
 
-        public int EntryCount => Entries.Count;
+        public int EntryCount => Entries.Length;
 
         internal override ulong CalculateSize()
         {
-            return base.CalculateSize() + 4 + ((ulong)Entries.Count * 4);
+            return base.CalculateSize() + 4 + ((ulong)Entries.Length * 4);
         }
 
         protected override void LoadFromStream(Stream stream)
@@ -30,9 +29,11 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             uint entryCount = stream.ReadBEUInt32();
 
+            Entries = new SyncSampleEntry[entryCount];
+
             for (uint i = 0; i < entryCount; i++)
             {
-                Entries.Add(new SyncSampleEntry(stream.ReadBEUInt32()));
+                Entries[i] = new SyncSampleEntry(stream.ReadBEUInt32());
             }
         }
 
@@ -40,11 +41,13 @@ namespace MatrixIO.IO.Bmff.Boxes
         {
             base.SaveToStream(stream);
 
-            stream.WriteBEUInt32((uint)Entries.Count);
+            stream.WriteBEUInt32((uint)Entries.Length);
 
-            foreach (SyncSampleEntry SyncSampleEntry in Entries)
+            for (int i = 0; i < Entries.Length; i++)
             {
-                stream.WriteBEUInt32(SyncSampleEntry.SampleNumber);
+                ref SyncSampleEntry entry = ref Entries[i];
+
+                stream.WriteBEUInt32(entry.SampleNumber);
             }
         }
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TimeToSampleBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TimeToSampleBox.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 
 namespace MatrixIO.IO.Bmff.Boxes
 {
@@ -12,16 +11,16 @@ namespace MatrixIO.IO.Bmff.Boxes
         public TimeToSampleBox()
             : base() { }
 
-        public TimeToSampleBox(Stream stream) 
+        public TimeToSampleBox(Stream stream)
             : base(stream) { }
 
-        public IList<TimeToSampleEntry> Entries { get; } = new List<TimeToSampleEntry>();
+        public TimeToSampleEntry[] Entries { get; set; }
 
-        public int EntryCount => Entries.Count;
+        public int EntryCount => Entries.Length;
 
         internal override ulong CalculateSize()
         {
-            return base.CalculateSize() + 4 + ((ulong)Entries.Count * (4 + 4));
+            return base.CalculateSize() + 4 + ((ulong)Entries.Length * (4 + 4));
         }
 
         protected override void LoadFromStream(Stream stream)
@@ -30,26 +29,29 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             uint entryCount = stream.ReadBEUInt32();
 
+            this.Entries = new TimeToSampleEntry[entryCount];
+
             for (uint i = 0; i < entryCount; i++)
             {
-                Entries.Add(new TimeToSampleEntry(
+                Entries[i] = new TimeToSampleEntry(
                     sampleCount: stream.ReadBEUInt32(),
                     sampleDelta: stream.ReadBEUInt32()
-                ));
+                );
             }
-
         }
 
         protected override void SaveToStream(Stream stream)
         {
             base.SaveToStream(stream);
 
-            stream.WriteBEUInt32((uint)Entries.Count);
+            stream.WriteBEUInt32((uint)Entries.Length);
 
-            foreach (TimeToSampleEntry TimeToSampleEntry in Entries)
+            for (var i = 0; i < Entries.Length; i++)
             {
-                stream.WriteBEUInt32(TimeToSampleEntry.SampleCount);
-                stream.WriteBEUInt32(TimeToSampleEntry.SampleDelta);
+                ref TimeToSampleEntry entry = ref Entries[i];
+
+                stream.WriteBEUInt32(entry.SampleCount);
+                stream.WriteBEUInt32(entry.SampleDelta);
             }
         }
 

--- a/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackFragmentRandomAccessBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/Boxes/TrackFragmentRandomAccessBox.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace MatrixIO.IO.Bmff.Boxes
 {
@@ -13,14 +11,19 @@ namespace MatrixIO.IO.Bmff.Boxes
     {
         private byte[] _reserved = new byte[4];
         private byte _sizeOf;
-        private readonly List<TrackFragmentEntry> _entries = new List<TrackFragmentEntry>();
 
-        public TrackFragmentRandomAccessBox() : base() { }
-        public TrackFragmentRandomAccessBox(Stream stream) : base(stream) { }
+        public TrackFragmentRandomAccessBox()
+            : base() { }
+
+        public TrackFragmentRandomAccessBox(Stream stream)
+            : base(stream) { }
+
+        public TrackFragmentEntry[] Entries { get; set; }
 
         internal override ulong CalculateSize()
         {
-            ulong entries = (ulong)Entries.Count;
+            ulong entries = (ulong)Entries.Length;
+
             return base.CalculateSize()
                 + 4 + 4 + 4
                 + (entries * (ulong)(Version == 0x01 ? 16 : 8))
@@ -39,46 +42,52 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             uint entryCount = stream.ReadBEUInt32();
 
+            Entries = new TrackFragmentEntry[entryCount];
+
             for (uint i = 0; i < entryCount; i++)
             {
-                var entry = new TrackFragmentEntry();
+                ulong time;
+                ulong moofOffset;
+                uint trafNumber;
+                uint trunNumber;
+                uint sampleNumber;
 
                 if (Version == 0x01)
                 {
-                    entry.Time = stream.ReadBEUInt64();
-                    entry.MoofOffset = stream.ReadBEUInt64();
+                    time = stream.ReadBEUInt64();
+                    moofOffset = stream.ReadBEUInt64();
                 }
                 else
                 {
-                    entry.Time = stream.ReadBEUInt32();
-                    entry.MoofOffset = stream.ReadBEUInt32();
+                    time = stream.ReadBEUInt32();
+                    moofOffset = stream.ReadBEUInt32();
                 }
 
                 switch (SizeOfTrafNumber)
                 {
-                    case 1: entry.TrafNumber = stream.ReadOneByte(); break;
-                    case 2: entry.TrafNumber = stream.ReadBEUInt16(); break;
-                    case 3: entry.TrafNumber = stream.ReadBEUInt24(); break;
-                    default: entry.TrafNumber = stream.ReadBEUInt32(); break;
+                    case 1: trafNumber = stream.ReadOneByte(); break;
+                    case 2: trafNumber = stream.ReadBEUInt16(); break;
+                    case 3: trafNumber = stream.ReadBEUInt24(); break;
+                    default: trafNumber = stream.ReadBEUInt32(); break;
                 }
 
                 switch (SizeOfTrunNumber)
                 {
-                    case 1: entry.TrunNumber = stream.ReadOneByte(); break;
-                    case 2: entry.TrunNumber = stream.ReadBEUInt16(); break;
-                    case 3: entry.TrunNumber = stream.ReadBEUInt24(); break;
-                    default: entry.TrunNumber = stream.ReadBEUInt32(); break;
+                    case 1: trunNumber = stream.ReadOneByte(); break;
+                    case 2: trunNumber = stream.ReadBEUInt16(); break;
+                    case 3: trunNumber = stream.ReadBEUInt24(); break;
+                    default: trunNumber = stream.ReadBEUInt32(); break;
                 }
 
                 switch (SizeOfSampleNumber)
                 {
-                    case 1: entry.SampleNumber = stream.ReadOneByte(); break;
-                    case 2: entry.SampleNumber = stream.ReadBEUInt16(); break;
-                    case 3: entry.SampleNumber = stream.ReadBEUInt24(); break;
-                    default: entry.SampleNumber = stream.ReadBEUInt32(); break;
+                    case 1: sampleNumber = stream.ReadOneByte(); break;
+                    case 2: sampleNumber = stream.ReadBEUInt16(); break;
+                    case 3: sampleNumber = stream.ReadBEUInt24(); break;
+                    default: sampleNumber = stream.ReadBEUInt32(); break;
                 }
 
-                _entries.Add(entry);
+                Entries[i] = new TrackFragmentEntry(time, moofOffset, trafNumber, trunNumber, sampleNumber);
             }
         }
 
@@ -94,20 +103,41 @@ namespace MatrixIO.IO.Bmff.Boxes
 
             bool has64BitEntry = false;
 
-            foreach (var entry in _entries)
+            uint maxFrafNumber = 0;
+            uint maxTrunNumber = 0;
+            uint maxSampleNumber = 0;
+
+            for (int i = 0; i < Entries.Length; i++)
             {
+                ref TrackFragmentEntry entry = ref Entries[i];
+
+                if (entry.TrafNumber > maxFrafNumber)
+                {
+                    maxFrafNumber = entry.TrafNumber;
+                }
+
+                if (entry.TrunNumber > maxTrunNumber)
+                {
+                    maxTrunNumber = entry.TrunNumber;
+                }
+
+                if (entry.SampleNumber > maxSampleNumber)
+                {
+                    maxFrafNumber = entry.SampleNumber;
+                }
+
                 if (entry.Time > uint.MaxValue || entry.MoofOffset > uint.MaxValue)
                 {
                     has64BitEntry = true;
 
                     break;
                 }
-            }            
+            }
 
-            SizeOfTrafNumber   = GetIntSize(_entries.Max(e => e.TrafNumber));
-            SizeOfTrunNumber   = GetIntSize(_entries.Max(e => e.TrunNumber));
-            SizeOfSampleNumber = GetIntSize(_entries.Max(e => e.SampleNumber));
-            Version            = has64BitEntry ? (byte)1 : (byte)0;
+            SizeOfTrafNumber = GetIntSize(maxFrafNumber);
+            SizeOfTrunNumber = GetIntSize(maxTrunNumber);
+            SizeOfSampleNumber = GetIntSize(maxSampleNumber);
+            Version = has64BitEntry ? (byte)1 : (byte)0;
 
             base.SaveToStream(stream);
 
@@ -115,10 +145,12 @@ namespace MatrixIO.IO.Bmff.Boxes
             stream.Write(_reserved, 0, 3);
             stream.WriteOneByte(_sizeOf);
 
-            stream.WriteBEUInt32((uint)_entries.Count);
+            stream.WriteBEUInt32((uint)Entries.Length);
 
-            foreach (var entry in _entries)
+            for (int i = 0; i < Entries.Length; i++)
             {
+                ref TrackFragmentEntry entry = ref Entries[i];
+
                 if (Version == 0x01)
                 {
                     stream.WriteBEUInt64(entry.Time);
@@ -157,7 +189,7 @@ namespace MatrixIO.IO.Bmff.Boxes
         }
 
         public uint TrackID { get; set; }
-        
+
         public sbyte SizeOfTrafNumber
         {
             get => (sbyte)(((_sizeOf & 0x30) >> 4) + 1);
@@ -171,6 +203,7 @@ namespace MatrixIO.IO.Bmff.Boxes
                 _sizeOf = (byte)((_sizeOf & 0xCF) | (((SizeOfTrafNumber - 1) & 0x30) << 4));
             }
         }
+
         public sbyte SizeOfTrunNumber
         {
             get => (sbyte)(((_sizeOf & 0x30) >> 4) + 1);
@@ -184,6 +217,7 @@ namespace MatrixIO.IO.Bmff.Boxes
                 _sizeOf = (byte)((_sizeOf & 0xF3) | ((SizeOfSampleNumber - 1) & 0x03));
             }
         }
+
         public sbyte SizeOfSampleNumber
         {
             get => (sbyte)(((_sizeOf & 0x30) >> 4) + 1);
@@ -198,21 +232,26 @@ namespace MatrixIO.IO.Bmff.Boxes
             }
         }
 
-        public class TrackFragmentEntry
+        public readonly struct TrackFragmentEntry
         {
-            public TrackFragmentEntry() { }
+            public TrackFragmentEntry(ulong time, ulong moofOffset, uint trafNumber, uint trunNumber, uint sampleNumber)
+            {
+                Time = time;
+                MoofOffset = moofOffset;
+                TrafNumber = trafNumber;
+                TrunNumber = trunNumber;
+                SampleNumber = sampleNumber;
+            }
 
-            public ulong Time { get; set; }
+            public ulong Time { get; }
 
-            public ulong MoofOffset { get; set; }
+            public ulong MoofOffset { get; }
 
-            public uint TrafNumber { get; set; }
+            public uint TrafNumber { get; }
 
-            public uint TrunNumber { get; set; }
+            public uint TrunNumber { get; }
 
-            public uint SampleNumber { get; set; }
+            public uint SampleNumber { get; }
         }
-
-        public IList<TrackFragmentEntry> Entries => _entries;
     }
 }

--- a/MatrixIO.IO.Bmff/IO/Bmff/ITableBox.cs
+++ b/MatrixIO.IO.Bmff/IO/Bmff/ITableBox.cs
@@ -1,11 +1,9 @@
-﻿using System.Collections.Generic;
-
-namespace MatrixIO.IO.Bmff
+﻿namespace MatrixIO.IO.Bmff
 {
     // TODO: There should be a better way to do this.  We don't want people using ITableBox directly under any circumstances.
     public interface ITableBox { }
     public interface ITableBox<EntryType> : ITableBox
     {
-        IList<EntryType> Entries { get; }
+        EntryType[] Entries { get; }
     }
 }


### PR DESCRIPTION
- Start of test coverage
- Eliminates ALL entry allocations by converting remaining classes to readonly structs
- Allocates entries array directly (rather then through virtual accessors on resizable list)
- Access all entry elements by reference

NOTE: changing Entries from an IList to an Array is a breaking change. The upside is that we are able to access the elements by reference without copies. This also sets us up to cast, convert, and wrap these in Span<T>.